### PR TITLE
DSpace updates and re-run updated transfers (deprecated)

### DIFF
--- a/fixtures/vcr_cassettes/get_next_transfer_missing_timestamps.yaml
+++ b/fixtures/vcr_cassettes/get_next_transfer_missing_timestamps.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.5.3 CPython/3.4.0 Linux/3.13.0-43-generic]
+    method: GET
+    uri: http://127.0.0.1:8000/api/v2/location/2a3d8d39-9cee-495e-b7ee-5e629254934d/browse/?path=U2FtcGxlVHJhbnNmZXJz
+  response:
+    body: {string: '{"directories": ["QmFnVHJhbnNmZXI=", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "c3RydWN0TWFwU2FtcGxl"], "entries":
+        ["QmFnVHJhbnNmZXI=", "QmFnVHJhbnNmZXIuemlw", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "U2FtcGxlVHJhbnNmZXJzU291cmNlcy50eHQ=",
+        "c3RydWN0TWFwU2FtcGxl"], "properties": {"Q1NWbWV0YWRhdGE=": {"timestamp":
+        "2013-05-13T13:26:48"}, "QmFnVHJhbnNmZXI=": {"timestamp": "2013-05-13T13:26:48"},
+        "QmFnVHJhbnNmZXIuemlw": {"size": 13187, "timestamp": "2013-05-13T13:26:48"},
+        "RFNwYWNlRXhwb3J0": {"timestamp": "2013-05-13T13:26:48"}, "RGlnaXRpemF0aW9uT3V0cHV0":
+        {"timestamp": "2013-05-13T13:26:48"}, "SVNPRGlza0ltYWdl": {"timestamp": "2014-06-05T11:06:03"},
+        "SW1hZ2Vz": {"timestamp": "2013-05-13T13:26:48"}, "T0NSSW1hZ2U=": {"timestamp":
+        "2014-10-07T12:09:30"}, "T2ZmaWNlRG9jcw==": {"timestamp": "2013-05-13T13:26:48"},
+        "TXVsdGltZWRpYQ==": {"timestamp": "2013-05-13T13:26:48"}, "U2FtcGxlVHJhbnNmZXJzU291cmNlcy50eHQ=":
+        {"size": 2047, "timestamp": "2013-05-13T13:26:49"}, "UmF3Q2FtZXJhSW1hZ2Vz":
+        {"timestamp": "2013-05-13T13:26:48"}, "c3RydWN0TWFwU2FtcGxl": {"timestamp":
+        "2013-05-13T13:26:49"}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Mon, 09 Mar 2015 19:53:45 GMT']
+      Server: [WSGIServer/0.1 Python/2.7.6]
+      Vary: ['Accept, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/get_next_transfer_no_new_timestamp.yaml
+++ b/fixtures/vcr_cassettes/get_next_transfer_no_new_timestamp.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.5.3 CPython/3.4.0 Linux/3.13.0-43-generic]
+    method: GET
+    uri: http://127.0.0.1:8000/api/v2/location/2a3d8d39-9cee-495e-b7ee-5e629254934d/browse/?path=U2FtcGxlVHJhbnNmZXJz
+  response:
+    body: {string: '{"directories": ["QmFnVHJhbnNmZXI=", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "c3RydWN0TWFwU2FtcGxl"], "entries":
+        ["QmFnVHJhbnNmZXI=", "QmFnVHJhbnNmZXIuemlw", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "U2FtcGxlVHJhbnNmZXJzU291cmNlcy50eHQ=",
+        "c3RydWN0TWFwU2FtcGxl"], "properties": {"Q1NWbWV0YWRhdGE=": {"timestamp":
+        "2013-05-13T13:26:48"}, "QmFnVHJhbnNmZXI=": {"timestamp": "2013-05-13T13:26:48"},
+        "QmFnVHJhbnNmZXIuemlw": {"size": 13187, "timestamp": "2013-05-13T13:26:48"},
+        "RFNwYWNlRXhwb3J0": {"timestamp": "2013-05-13T13:26:48"}, "RGlnaXRpemF0aW9uT3V0cHV0":
+        {"timestamp": "2013-05-13T13:26:48"}, "SVNPRGlza0ltYWdl": {"timestamp": "2014-06-05T11:06:03"},
+        "SW1hZ2Vz": {"timestamp": "2013-05-13T13:26:48"}, "T0NSSW1hZ2U=": {"timestamp":
+        "2014-10-07T12:09:30"}, "T2ZmaWNlRG9jcw==": {"timestamp": "2013-05-13T13:26:48"},
+        "TXVsdGltZWRpYQ==": {"timestamp": "2013-05-13T13:26:48"}, "U2FtcGxlVHJhbnNmZXJzU291cmNlcy50eHQ=":
+        {"size": 2047, "timestamp": "2013-05-13T13:26:49"}, "UmF3Q2FtZXJhSW1hZ2Vz":
+        {"timestamp": "2013-05-13T13:26:48"}, "c3RydWN0TWFwU2FtcGxl": {"timestamp":
+        "2013-05-13T13:26:49"}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Mon, 09 Mar 2015 19:50:11 GMT']
+      Server: [WSGIServer/0.1 Python/2.7.6]
+      Vary: ['Accept, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/get_next_transfer_updated_timestamp.yaml
+++ b/fixtures/vcr_cassettes/get_next_transfer_updated_timestamp.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.5.3 CPython/3.4.0 Linux/3.13.0-43-generic]
+    method: GET
+    uri: http://127.0.0.1:8000/api/v2/location/2a3d8d39-9cee-495e-b7ee-5e629254934d/browse/?path=U2FtcGxlVHJhbnNmZXJz
+  response:
+    body: {string: '{"directories": ["QmFnVHJhbnNmZXI=", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "c3RydWN0TWFwU2FtcGxl"], "entries":
+        ["QmFnVHJhbnNmZXI=", "QmFnVHJhbnNmZXIuemlw", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "U2FtcGxlVHJhbnNmZXJzU291cmNlcy50eHQ=",
+        "c3RydWN0TWFwU2FtcGxl"], "properties": {"Q1NWbWV0YWRhdGE=": {"timestamp":
+        "2013-05-13T13:26:48"}, "QmFnVHJhbnNmZXI=": {"timestamp": "2013-05-13T13:26:48"},
+        "QmFnVHJhbnNmZXIuemlw": {"size": 13187, "timestamp": "2013-05-13T13:26:48"},
+        "RFNwYWNlRXhwb3J0": {"timestamp": "2013-05-13T13:26:48"}, "RGlnaXRpemF0aW9uT3V0cHV0":
+        {"timestamp": "2013-05-13T13:26:48"}, "SVNPRGlza0ltYWdl": {"timestamp": "2014-06-05T11:06:03"},
+        "SW1hZ2Vz": {"timestamp": "2013-05-13T13:26:48"}, "T0NSSW1hZ2U=": {"timestamp":
+        "2014-10-07T12:09:30"}, "T2ZmaWNlRG9jcw==": {"timestamp": "2013-05-13T13:26:48"},
+        "TXVsdGltZWRpYQ==": {"timestamp": "2013-05-13T13:26:48"}, "U2FtcGxlVHJhbnNmZXJzU291cmNlcy50eHQ=":
+        {"size": 2047, "timestamp": "2013-05-13T13:26:49"}, "UmF3Q2FtZXJhSW1hZ2Vz":
+        {"timestamp": "2013-05-13T13:26:48"}, "c3RydWN0TWFwU2FtcGxl": {"timestamp":
+        "2013-05-13T13:26:49"}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Mon, 09 Mar 2015 19:50:12 GMT']
+      Server: [WSGIServer/0.1 Python/2.7.6]
+      Vary: ['Accept, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 requests<3.0
+python-dateutil
 sqlalchemy
 six

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from collections import namedtuple
+from datetime import datetime
 import os
 import unittest
 
@@ -21,15 +23,19 @@ PATH_PREFIX = b'SampleTransfers'
 DEPTH = 1
 COMPLETED = set()
 FILES = False
+TimestampsMock = namedtuple('TimestampsMock', ['path', 'started_timestamp'])
 
 engine = create_engine('sqlite:///:memory:')
 models.Base.metadata.create_all(engine)
 Session = sessionmaker(bind=engine)
 session = Session()
 
+my_vcr = vcr.VCR(
+    filter_query_parameters=['username', 'api_key']
+)
 
 class TestAutomateTransfers(unittest.TestCase):
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_status_transfer.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_status_transfer.yaml')
     def test_get_status_transfer(self):
         transfer_uuid = 'dfc8cf5f-b5b1-408c-88b1-34215964e9d6'
         transfer_name = 'test1'
@@ -42,7 +48,7 @@ class TestAutomateTransfers(unittest.TestCase):
         assert info['directory'] == transfer_name
         assert info['path'] == '/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer/test1/'
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_status_transfer_to_ingest.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_status_transfer_to_ingest.yaml')
     def test_get_status_transfer_to_ingest(self):
         # Reference values
         transfer_uuid = 'dfc8cf5f-b5b1-408c-88b1-34215964e9d6'
@@ -64,7 +70,7 @@ class TestAutomateTransfers(unittest.TestCase):
         assert info['directory'] == unit_name + '-' + sip_uuid
         assert info['path'] == '/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/test1-f2248e2a-b593-43db-b60c-fa8513021785/'
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_status_ingest.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_status_ingest.yaml')
     def test_get_status_ingest(self):
         sip_uuid = 'f2248e2a-b593-43db-b60c-fa8513021785'
         sip_name = 'test1'
@@ -77,13 +83,13 @@ class TestAutomateTransfers(unittest.TestCase):
         assert info['directory'] == sip_name + '-' + sip_uuid
         assert info['path'] == '/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/test1-f2248e2a-b593-43db-b60c-fa8513021785/'
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_status_no_unit.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_status_no_unit.yaml')
     def test_get_status_no_unit(self):
         transfer_uuid = 'deadc0de-c0de-c0de-c0de-deadc0dec0de'
         info = transfer.get_status(AM_URL, USER, API_KEY, transfer_uuid, 'transfer', session)
         assert info is None
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_status_not_json.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_status_not_json.yaml')
     def test_get_status_not_json(self):
         transfer_uuid = 'dfc8cf5f-b5b1-408c-88b1-34215964e9d6'
         info = transfer.get_status(AM_URL, USER, API_KEY, transfer_uuid, 'transfer', session)
@@ -93,7 +99,7 @@ class TestAutomateTransfers(unittest.TestCase):
         accession_id = transfer.get_accession_id(os.path.curdir)
         assert accession_id is None
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_first_run.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_first_run.yaml')
     def test_get_next_transfer_first_run(self):
         # All default values
         # Test
@@ -101,7 +107,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Verify
         assert path == b'SampleTransfers/BagTransfer'
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_existing_set.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_existing_set.yaml')
     def test_get_next_transfer_existing_set(self):
         # Set completed set
         completed = {b'SampleTransfers/BagTransfer'}
@@ -110,7 +116,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Verify
         assert path == b'SampleTransfers/CSVmetadata'
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_depth.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_depth.yaml')
     def test_get_next_transfer_depth(self):
         # Set depth
         depth = 2
@@ -119,7 +125,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Verify
         assert path == b'SampleTransfers/BagTransfer/data'
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_no_prefix.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_no_prefix.yaml')
     def test_get_next_transfer_no_prefix(self):
         # Set no prefix
         path_prefix = b''
@@ -128,7 +134,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Verify
         assert path == b'OPF format-corpus'
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_all_complete.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_all_complete.yaml')
     def test_get_next_transfer_all_complete(self):
         # Set completed set to be all elements
         completed = {b'SampleTransfers/BagTransfer', b'SampleTransfers/CSVmetadata', b'SampleTransfers/DigitizationOutput', b'SampleTransfers/DSpaceExport', b'SampleTransfers/Images', b'SampleTransfers/ISODiskImage', b'SampleTransfers/Multimedia', b'SampleTransfers/OCRImage', b'SampleTransfers/OfficeDocs', b'SampleTransfers/RawCameraImages', b'SampleTransfers/structMapSample'}
@@ -137,7 +143,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Verify
         assert path is None
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_bad_source.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_bad_source.yaml')
     def test_get_next_transfer_bad_source(self):
         # Set bad TS Location UUID
         ts_location_uuid = 'badd8d39-9cee-495e-b7ee-5e6292549bad'
@@ -146,7 +152,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Verify
         assert path is None
 
-    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_files.yaml')
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_files.yaml')
     def test_get_next_transfer_files(self):
         # See files
         files = True
@@ -156,6 +162,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Verify
         assert path == b'SampleTransfers/BagTransfer.zip'
 
+    # Not ignoring the auth parameters
     @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_failed_auth.yaml')
     def test_get_next_transfer_failed_auth(self):
         # All default values
@@ -163,5 +170,62 @@ class TestAutomateTransfers(unittest.TestCase):
         ss_key = 'dne'
         # Test
         path = transfer.get_next_transfer(SS_URL, ss_user, ss_key, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, COMPLETED, FILES)
+        # Verify
+        assert path is None
+
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_updated_timestamp.yaml')
+    def test_get_next_transfer_updated_timestamp(self):
+        # Set timestamps
+        completed = {b'SampleTransfers/BagTransfer', b'SampleTransfers/CSVmetadata', b'SampleTransfers/DigitizationOutput', b'SampleTransfers/DSpaceExport', b'SampleTransfers/Images', b'SampleTransfers/ISODiskImage', b'SampleTransfers/Multimedia', b'SampleTransfers/OCRImage', b'SampleTransfers/OfficeDocs', b'SampleTransfers/RawCameraImages', b'SampleTransfers/structMapSample'}
+        started_timestamps = [
+            TimestampsMock(b'SampleTransfers/BagTransfer', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/Images', datetime(2010, 1, 1)),
+        ]
+        # Test
+        path = transfer.get_next_transfer(SS_URL, SS_USER, SS_KEY, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed, FILES, started_timestamps)
+        # Verify
+        assert path == b'SampleTransfers/Images'
+
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_no_new_timestamp.yaml')
+    def test_get_next_transfer_no_new_timestamp(self):
+        # Set timestamps
+        completed = {b'SampleTransfers/BagTransfer', b'SampleTransfers/CSVmetadata', b'SampleTransfers/DigitizationOutput', b'SampleTransfers/DSpaceExport', b'SampleTransfers/Images', b'SampleTransfers/ISODiskImage', b'SampleTransfers/Multimedia', b'SampleTransfers/OCRImage', b'SampleTransfers/OfficeDocs', b'SampleTransfers/RawCameraImages', b'SampleTransfers/structMapSample'}
+        started_timestamps = [
+            TimestampsMock(b'SampleTransfers/BagTransfer', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/CSVmetadata', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/DigitizationOutput', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/DSpaceExport', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/Images', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/ISODiskImage', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/Multimedia', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/OCRImage', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/OfficeDocs', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/RawCameraImages', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/structMapSample', datetime(2020, 1, 1)),
+        ]
+        # Test
+        path = transfer.get_next_transfer(SS_URL, SS_USER, SS_KEY, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed, FILES, started_timestamps)
+        # Verify
+        assert path is None
+
+    @my_vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_missing_timestamps.yaml')
+    def test_get_next_transfer_missing_timestamps(self):
+        # Set timestamps
+        completed = {b'SampleTransfers/BagTransfer', b'SampleTransfers/CSVmetadata', b'SampleTransfers/DigitizationOutput', b'SampleTransfers/DSpaceExport', b'SampleTransfers/Images', b'SampleTransfers/ISODiskImage', b'SampleTransfers/Multimedia', b'SampleTransfers/OCRImage', b'SampleTransfers/OfficeDocs', b'SampleTransfers/RawCameraImages', b'SampleTransfers/structMapSample'}
+        started_timestamps = [
+            TimestampsMock(b'SampleTransfers/BagTransfer', None),
+            TimestampsMock(b'SampleTransfers/CSVmetadata', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/DigitizationOutput', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/DSpaceExport', None),
+            TimestampsMock(b'SampleTransfers/Images', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/ISODiskImage', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/Multimedia', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/OCRImage', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/OfficeDocs', datetime(2020, 1, 1)),
+            TimestampsMock(b'SampleTransfers/RawCameraImages', None),
+            TimestampsMock(b'SampleTransfers/structMapSample', datetime(2020, 1, 1)),
+        ]
+        # Test
+        path = transfer.get_next_transfer(SS_URL, SS_USER, SS_KEY, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed, FILES, started_timestamps)
         # Verify
         assert path is None

--- a/transfers/amclient.py
+++ b/transfers/amclient.py
@@ -200,8 +200,7 @@ def get_parser():
         description='Archivematica Client',
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
-        '--config-file', metavar='FILE', help='Configuration'
-        ' file (log/db/PID files)', default=DEFAULT_LOGFILE)
+        '--log-file', metavar='FILE', help='logfile', default=DEFAULT_LOGFILE)
     parser.add_argument(
         '--log-level', choices=['ERROR', 'WARNING', 'INFO', 'DEBUG'],
         default='INFO', help='Set the debugging output level.')
@@ -580,7 +579,7 @@ class AMClient:
 def main():
     parser = get_parser()
     args = parser.parse_args()
-    setup_logger(args.config_file, args.log_level)
+    setup_logger(args.log_file, args.log_level)
     am_client = AMClient(**vars(args))
     try:
         getattr(am_client, 'print_{0}'.format(args.subcommand.replace('-', '_')))

--- a/transfers/examples/pre-transfer/add_metadata_dspace.py
+++ b/transfers/examples/pre-transfer/add_metadata_dspace.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import csv
+import os
+import re
+import sys
+
+def main(transfer_path):
+    """
+    Add DSpace identifier to SIP metadata.
+
+    Check for files in the transfer path. If there is exactly one, parse out the identifier.
+
+    Example filenames -> ID:
+    COLLECTION@2429-11123.zip -> 2429/11123
+    COMMUNITY@2429-1036.zip -> 2429/1036
+    ITEM@2429-100.zip -> 2429/100
+    ITEM@2429-1005.zip -> 2429/1005
+    ITEM@2429-10029.zip -> 2429/10029
+    SITE@2429-0.zip -> 2429/0
+    """
+    files = os.listdir(transfer_path)
+    if len(files) != 1:
+        return 2
+    basename = os.path.basename(files[0])
+    regex = r'[\w]+@([\d]+)-([\d]+)\.zip$'
+    match = re.search(regex, basename)
+    if not match:
+        return 1
+
+    dc_id = '/'.join(match.groups())
+    print('Identifier: ', dc_id, end='')
+    header = ['parts', 'dc.identifier']
+    data = ['objects', dc_id]
+    metadata_path = os.path.join(transfer_path, 'metadata')
+    if not os.path.exists(metadata_path):
+        os.makedirs(metadata_path)
+    metadata_path = os.path.join(metadata_path, 'metadata.csv')
+    with open(metadata_path, 'w') as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerow(data)
+    return 0
+
+if __name__ == '__main__':
+    transfer_path = sys.argv[1]
+    sys.exit(main(transfer_path))

--- a/transfers/examples/pre-transfer/defaultProcessingMCP.xml
+++ b/transfers/examples/pre-transfer/defaultProcessingMCP.xml
@@ -68,5 +68,10 @@
       <appliesTo>b320ce81-9982-408a-9502-097d0daa48fa</appliesTo>
       <goToChain>/api/v2/location/edc821af-b9c0-480f-9465-e6b38b23dc99/</goToChain>
     </preconfiguredChoice>
+    <!-- DSpace skips quarantine -->
+    <preconfiguredChoice>
+      <appliesTo>05f99ffd-abf2-4f5a-9ec8-f80a59967b89</appliesTo>
+      <goToChain>d4404ab1-dc7f-4e9e-b1f8-aa861e766b8e</goToChain>
+    </preconfiguredChoice>
   </preconfiguredChoices>
 </processingMCP>

--- a/transfers/models.py
+++ b/transfers/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy import Sequence
-from sqlalchemy import Column, Binary, Boolean, Integer, String
+from sqlalchemy import Column, Binary, Boolean, Integer, String, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -16,9 +16,10 @@ class Unit(Base):
     status = Column(String(20), nullable=True)
     microservice = Column(String(50))
     current = Column(Boolean(create_constraint=False))
+    started_timestamp = Column(DateTime(timezone=True))  # UTC time started
 
     def __repr__(self):
-        return "<Unit(id={s.id}, uuid={s.uuid}, unit_type={s.unit_type}, path={s.path}, status={s.status}, current={s.current})>".format(s=self)
+        return "<Unit(id={s.id}, uuid={s.uuid}, unit_type={s.unit_type}, path={s.path}, status={s.status}, current={s.current}, timestamp={s.started_timestamp})>".format(s=self)
 
 
 def init(databasefile):

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -342,7 +342,7 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
     """
     # Start new transfer
     completed = {x[0] for x in session.query(models.Unit.path).all()}
-    transfer_start_times = session.query(Unit.path, Unit.started_timestamp)
+    transfer_start_times = session.query(models.Unit.path, models.Unit.started_timestamp)
     target = get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth, completed, see_files, transfer_start_times)
     if not target:
         LOGGER.warning("All potential transfers in %s have been created. Exiting", ts_path)

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -10,6 +10,7 @@ import argparse
 import ast
 import base64
 import datetime
+from dateutil.parser import parse
 import logging
 import logging.config  # Has to be imported separately
 import os
@@ -226,7 +227,7 @@ def run_scripts(directory, *args):
             LOGGER.warning('stderr: %s', stderr)
 
 
-def get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, path_prefix, depth, completed, see_files):
+def get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, path_prefix, depth, completed, see_files, transfer_start_times=None):
     """
     Helper to find the first directory that doesn't have an associated transfer.
 
@@ -238,6 +239,7 @@ def get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, path_prefix
     :param depth: Depth relative to path_prefix to create a transfer from. Should be 1 or greater.
     :param set completed: Set of the paths of completed transfers. Ideally, relative to the same transfer source location, including the same path_prefix, and at the same depth.
     :param bool see_files: Return files as well as folders to become transfers.
+    :param transfer_start_times: List of objects with attributes 'path' and 'started_timestamp'. Likely a SQLAlchemy query, but could also be a NamedTuple.
     :returns: Path relative to TS Location of the new transfer
     """
     # Get sorted list from source dir
@@ -263,18 +265,36 @@ def get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, path_prefix
         # Find the directories that are not already in the DB using sets
         entries = set(entries) - completed
         LOGGER.debug("New transfer candidates: %s", entries)
+        if not entries:
+            LOGGER.info("All potential transfers in %s have been created. Checking for updated transfers", path_prefix)
+            if not transfer_start_times:
+                LOGGER.info('Starting times for transfers not provided.')
+                return None
+            # Find transfers whose started_timestamp is newer than the one provided by browse
+            browse_timestamps = {
+                os.path.join(path_prefix, base64.b64decode(e)): parse(d['timestamp'])
+                for e, d in browse_info['properties'].items()
+                if 'timestamp' in d
+            }
+            LOGGER.debug('browse_timestamps: %s', browse_timestamps)
+            LOGGER.debug('transfer_start_times: %s', list(transfer_start_times))
+            updated = {
+                e.path
+                for e in transfer_start_times
+                if e.started_timestamp and e.path in browse_timestamps and browse_timestamps[e.path] > e.started_timestamp}
+            LOGGER.debug('Updated transfer candidates: %s', updated)
+            entries = updated
+        if not entries:
+            return None
         # Sort, take the first
         entries = sorted(list(entries))
-        if not entries:
-            LOGGER.info("All potential transfers in %s have been created.", path_prefix)
-            return None
         target = entries[0]
         return target
     else:  # if depth > 1
         # Recurse on each directory
         for e in entries:
             LOGGER.debug('New path: %s', e)
-            target = get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, e, depth - 1, completed, see_files)
+            target = get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, e, depth - 1, completed, see_files, transfer_start_times)
             if target:
                 return target
     return None
@@ -299,7 +319,8 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
     """
     # Start new transfer
     completed = {x[0] for x in session.query(models.Unit.path).all()}
-    target = get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth, completed, see_files)
+    transfer_start_times = session.query(Unit.path, Unit.started_timestamp)
+    target = get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth, completed, see_files, transfer_start_times)
     if not target:
         LOGGER.warning("All potential transfers in %s have been created. Exiting", ts_path)
         return None
@@ -329,7 +350,7 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
     if not response.ok or resp_json.get('error'):
         LOGGER.error('Unable to start transfer.')
         LOGGER.error('Response: %s', resp_json)
-        new_transfer = models.Unit(path=target, unit_type='transfer', status='FAILED', current=False, started_timestamp=datetime.datetime.utcnow())
+        new_transfer = models.Unit(path=target, unit_type='transfer', status='FAILED', current=False, started_timestamp=datetime.datetime.now())
         session.add(new_transfer)
         return None
 
@@ -349,7 +370,7 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
         # Mark as started
         if result:
             LOGGER.info('Approved %s', result)
-            new_transfer = models.Unit(uuid=result, path=target, unit_type='transfer', current=True, started_timestamp=datetime.datetime.utcnow())
+            new_transfer = models.Unit(uuid=result, path=target, unit_type='transfer', current=True, started_timestamp=datetime.datetime.now())
             LOGGER.info('New transfer: %s', new_transfer)
             session.add(new_transfer)
             break

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -87,8 +87,8 @@ def setup(config_file, log_level):
                 'class': 'logging.handlers.RotatingFileHandler',
                 'formatter': 'default',
                 'filename': get_setting('logfile', default_logfile),
-                'backupCount': 2,
-                'maxBytes': 10 * 1024,
+                'backupCount': 20,
+                'maxBytes': 10 * 1024 * 1024,
             },
         },
         'loggers': {

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -16,6 +16,7 @@ import logging.config  # Has to be imported separately
 import os
 import requests
 from six.moves import configparser
+from sqlalchemy import inspect
 import subprocess
 import sys
 import time
@@ -300,6 +301,28 @@ def get_next_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, path_prefix
     return None
 
 
+def create_or_update_unit(session, path, **kwargs):
+    """
+    Create a new Unit, or update an existing one with the same path.
+
+    :param session: SQLAlchemy session with the DB
+    :param path: Path for the new Unit, or Unit to be updated
+    :parma kwargs: Other attributes for the new Unit. Should be attributes of Unit.
+    :return: New or updated transfer
+    """
+    unit_attrs = [c.key for c in inspect(models.Unit).attrs if c.key not in ('id', 'path',)]
+    params = {k: v for k, v in kwargs.items() if k in unit_attrs}
+    params['path'] = path
+    try:
+        new_unit = session.query(models.Unit).filter_by(path=path)[0]
+        for attr, value in params.items():
+            setattr(new_unit, attr, value)
+    except IndexError:
+        new_unit = models.Unit(**params)
+    new_unit = session.merge(new_unit)
+    return new_unit
+
+
 def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth, am_url, am_user, am_api_key, transfer_type, see_files, session):
     """
     Starts a new transfer.
@@ -350,8 +373,7 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
     if not response.ok or resp_json.get('error'):
         LOGGER.error('Unable to start transfer.')
         LOGGER.error('Response: %s', resp_json)
-        new_transfer = models.Unit(path=target, unit_type='transfer', status='FAILED', current=False, started_timestamp=datetime.datetime.now())
-        session.add(new_transfer)
+        new_transfer = create_or_update_unit(session, path=target, unit_type='transfer', status='FAILED', current=False, started_timestamp=datetime.datetime.now())
         return None
 
     # Run all scripts in pre-transfer directory
@@ -370,15 +392,13 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
         # Mark as started
         if result:
             LOGGER.info('Approved %s', result)
-            new_transfer = models.Unit(uuid=result, path=target, unit_type='transfer', current=True, started_timestamp=datetime.datetime.now())
+            new_transfer = create_or_update_unit(session, path=target, uuid=result, unit_type='transfer', current=True, started_timestamp=datetime.datetime.now())
             LOGGER.info('New transfer: %s', new_transfer)
-            session.add(new_transfer)
             break
         LOGGER.info('Failed approve, try %s of %s', i + 1, retry_count)
     else:
         LOGGER.warning('Not approved')
-        new_transfer = models.Unit(uuid=None, path=target, unit_type='transfer', current=False, started_timestamp=datetime.datetime.utcnow())
-        session.add(new_transfer)
+        new_transfer = create_or_update_unit(session, path=target, uuid=None, unit_type='transfer', current=False, started_timestamp=datetime.datetime.now())
         return None
 
     LOGGER.info('Finished %s', target)

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -9,6 +9,7 @@ from __future__ import print_function, unicode_literals
 import argparse
 import ast
 import base64
+import datetime
 import logging
 import logging.config  # Has to be imported separately
 import os
@@ -328,7 +329,7 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
     if not response.ok or resp_json.get('error'):
         LOGGER.error('Unable to start transfer.')
         LOGGER.error('Response: %s', resp_json)
-        new_transfer = models.Unit(path=target, unit_type='transfer', status='FAILED', current=False)
+        new_transfer = models.Unit(path=target, unit_type='transfer', status='FAILED', current=False, started_timestamp=datetime.datetime.utcnow())
         session.add(new_transfer)
         return None
 
@@ -348,14 +349,14 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth
         # Mark as started
         if result:
             LOGGER.info('Approved %s', result)
-            new_transfer = models.Unit(uuid=result, path=target, unit_type='transfer', current=True)
+            new_transfer = models.Unit(uuid=result, path=target, unit_type='transfer', current=True, started_timestamp=datetime.datetime.utcnow())
             LOGGER.info('New transfer: %s', new_transfer)
             session.add(new_transfer)
             break
         LOGGER.info('Failed approve, try %s of %s', i + 1, retry_count)
     else:
         LOGGER.warning('Not approved')
-        new_transfer = models.Unit(uuid=None, path=target, unit_type='transfer', current=False)
+        new_transfer = models.Unit(uuid=None, path=target, unit_type='transfer', current=False, started_timestamp=datetime.datetime.utcnow())
         session.add(new_transfer)
         return None
 


### PR DESCRIPTION
- Add DSpace specific pre-transfer metadata processing
- Re-run transfers in transfer source that have been updated.  This does not currently handle timezones.

Supporting, now in #3 and #4:
- Switch to using argparse instead of docopt because argparse does input validation
- Support running with Python2 or Python3
- Add and update tests
- Add support for different transfer types
