### PR TITLE
Support different transfer types, transfers from files

### DIFF
--- a/fixtures/vcr_cassettes/get_next_transfer_files.yaml
+++ b/fixtures/vcr_cassettes/get_next_transfer_files.yaml
@@ -1,0 +1,27 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.5.3 CPython/3.4.0 Linux/3.13.0-43-generic]
+    method: GET
+    uri: http://127.0.0.1:8000/api/v2/location/2a3d8d39-9cee-495e-b7ee-5e629254934d/browse/?path=U2FtcGxlVHJhbnNmZXJz
+  response:
+    body: {string: '{"directories": ["QmFnVHJhbnNmZXI=", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "c3RydWN0TWFwU2FtcGxl"], "entries":
+        ["QmFnVHJhbnNmZXI=", "QmFnVHJhbnNmZXIuemlw", "Q1NWbWV0YWRhdGE=", "RGlnaXRpemF0aW9uT3V0cHV0",
+        "RFNwYWNlRXhwb3J0", "SW1hZ2Vz", "SVNPRGlza0ltYWdl", "TXVsdGltZWRpYQ==", "T0NSSW1hZ2U=",
+        "T2ZmaWNlRG9jcw==", "UmF3Q2FtZXJhSW1hZ2Vz", "U2FtcGxlVHJhbnNmZXJzU291cmNlcy50eHQ=",
+        "c3RydWN0TWFwU2FtcGxl"]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Mon, 02 Mar 2015 23:38:59 GMT']
+      Server: [WSGIServer/0.1 Python/2.7.6]
+      Vary: ['Accept, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -18,6 +18,7 @@ TS_LOCATION_UUID = '2a3d8d39-9cee-495e-b7ee-5e629254934d'
 PATH_PREFIX = b'SampleTransfers'
 DEPTH = 1
 COMPLETED = set()
+FILES = False
 
 engine = create_engine('sqlite:///:memory:')
 models.Base.metadata.create_all(engine)
@@ -90,7 +91,7 @@ class TestAutomateTransfers(unittest.TestCase):
     def test_get_next_transfer_first_run(self):
         # All default values
         # Test
-        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, COMPLETED)
+        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, COMPLETED, FILES)
         # Verify
         assert path == b'SampleTransfers/BagTransfer'
 
@@ -99,7 +100,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Set completed set
         completed = {b'SampleTransfers/BagTransfer'}
         # Test
-        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed)
+        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed, FILES)
         # Verify
         assert path == b'SampleTransfers/CSVmetadata'
 
@@ -108,7 +109,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Set depth
         depth = 2
         # Test
-        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, depth, COMPLETED)
+        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, depth, COMPLETED, FILES)
         # Verify
         assert path == b'SampleTransfers/BagTransfer/data'
 
@@ -117,7 +118,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Set no prefix
         path_prefix = b''
         # Test
-        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, path_prefix, DEPTH, COMPLETED)
+        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, path_prefix, DEPTH, COMPLETED, FILES)
         # Verify
         assert path == b'OPF format-corpus'
 
@@ -126,7 +127,7 @@ class TestAutomateTransfers(unittest.TestCase):
         # Set completed set to be all elements
         completed = {b'SampleTransfers/BagTransfer', b'SampleTransfers/CSVmetadata', b'SampleTransfers/DigitizationOutput', b'SampleTransfers/DSpaceExport', b'SampleTransfers/Images', b'SampleTransfers/ISODiskImage', b'SampleTransfers/Multimedia', b'SampleTransfers/OCRImage', b'SampleTransfers/OfficeDocs', b'SampleTransfers/RawCameraImages', b'SampleTransfers/structMapSample'}
         # Test
-        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed)
+        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed, FILES)
         # Verify
         assert path is None
 
@@ -135,6 +136,16 @@ class TestAutomateTransfers(unittest.TestCase):
         # Set bad TS Location UUID
         ts_location_uuid = 'badd8d39-9cee-495e-b7ee-5e6292549bad'
         # Test
-        path = transfer.get_next_transfer(SS_URL, ts_location_uuid, PATH_PREFIX, DEPTH, COMPLETED)
+        path = transfer.get_next_transfer(SS_URL, ts_location_uuid, PATH_PREFIX, DEPTH, COMPLETED, FILES)
         # Verify
         assert path is None
+
+    @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_files.yaml')
+    def test_get_next_transfer_files(self):
+        # See files
+        files = True
+        completed = {b'SampleTransfers/BagTransfer'}
+        # Test
+        path = transfer.get_next_transfer(SS_URL, TS_LOCATION_UUID, PATH_PREFIX, DEPTH, completed, files)
+        # Verify
+        assert path == b'SampleTransfers/BagTransfer.zip'

--- a/transfers/pre-transfer/00_file_to_folder.py
+++ b/transfers/pre-transfer/00_file_to_folder.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, unicode_literals
+import datetime
+import os
+import sys
+
+def main(transfer_path):
+    """
+    If transfer_path is a file, move into a directory of the same name.
+    """
+    if os.path.isdir(transfer_path):
+        return 1
+    # Move file into temp dir
+    transfer_dir, transfer_name = os.path.split(transfer_path)
+    temp_dir = os.path.join(transfer_dir, 'temp-' + str(datetime.datetime.utcnow()))
+    os.mkdir(temp_dir)
+    os.rename(transfer_path, os.path.join(temp_dir, transfer_name))
+    # Rename temp dir to the same as the file
+    os.rename(temp_dir, transfer_path)
+
+if __name__ == '__main__':
+    transfer_path = sys.argv[1]
+    main(transfer_path)

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -225,7 +225,7 @@ def get_next_transfer(ss_url, ts_location_uuid, path_prefix, depth, completed):
     return None
 
 
-def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, api_key, session):
+def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, api_key, transfer_type, session):
     """
     Starts a new transfer.
 
@@ -255,7 +255,7 @@ def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, 
     target_name = os.path.basename(target)
     data = {
         'name': target_name,
-        'type': 'standard',
+        'type': transfer_type,
         'accession': accession,
         'paths[]': [base64.b64encode(fsencode(ts_location_uuid) + b':' + target)],
         'row_ids[]': [''],
@@ -338,7 +338,7 @@ def approve_transfer(directory_name, url, api_key, user_name):
     else:
         return None
 
-def main(user, api_key, ts_uuid, ts_path, depth, am_url, ss_url):
+def main(user, api_key, ts_uuid, ts_path, depth, am_url, ss_url, transfer_type):
     LOGGER.info("Waking up")
     session = Session()
 
@@ -403,7 +403,7 @@ def main(user, api_key, ts_uuid, ts_path, depth, am_url, ss_url):
     # If failed, rejected, completed etc, start new transfer
     if current_unit:
         current_unit.current = False
-    new_transfer = start_transfer(ss_url, ts_uuid, ts_path, depth, am_url, user, api_key, session)
+    new_transfer = start_transfer(ss_url, ts_uuid, ts_path, depth, am_url, user, api_key, transfer_type, session)
 
     session.commit()
     os.remove(pid_file)
@@ -419,7 +419,7 @@ if __name__ == '__main__':
     parser.add_argument('--depth', '-d', help='Depth to create the transfers from relative to the transfer source location and path. Default of 1 creates transfers from the children of transfer-path.', type=int, default=1)
     parser.add_argument('--am-url', '-a', metavar='URL', help='Archivematica URL. Default: http://127.0.0.1', default='http://127.0.0.1')
     parser.add_argument('--ss-url', '-s', metavar='URL', help='Storage Service URL. Default: http://127.0.0.1:8000', default='http://127.0.0.1:8000')
-    parser.add_argument('--transfer-type', metavar='TYPE', help="Type of transfer to start. One of: 'standard' (default), 'unzipped bag', 'zipped bag', 'dspace'.  Unimplemented.", default='standard', choices=['standard', 'unzipped bag', 'zipped bag', 'dspace'])
+    parser.add_argument('--transfer-type', metavar='TYPE', help="Type of transfer to start. One of: 'standard' (default), 'unzipped bag', 'zipped bag', 'dspace'.", default='standard', choices=['standard', 'unzipped bag', 'zipped bag', 'dspace'])
     parser.add_argument('--files', action='store_true', help='Start transfers from files as well as folders. Unimplemented.')
     args = parser.parse_args()
 
@@ -431,4 +431,5 @@ if __name__ == '__main__':
         depth=args.depth,
         am_url=args.am_url,
         ss_url=args.ss_url,
+        transfer_type=args.transfer_type
     ))

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -180,7 +180,7 @@ def run_scripts(directory, *args):
             LOGGER.warning('stderr: %s', stderr)
 
 
-def get_next_transfer(ss_url, ts_location_uuid, path_prefix, depth, completed):
+def get_next_transfer(ss_url, ts_location_uuid, path_prefix, depth, completed, see_files):
     """
     Helper to find the first directory that doesn't have an associated transfer.
 
@@ -189,6 +189,7 @@ def get_next_transfer(ss_url, ts_location_uuid, path_prefix, depth, completed):
     :param path_prefix: Relative path inside the Location to work with.
     :param depth: Depth relative to path_prefix to create a transfer from. Should be 1 or greater.
     :param set completed: Set of the paths of completed transfers. Ideally, relative to the same transfer source location, including the same path_prefix, and at the same depth.
+    :param bool see_files: Return files as well as folders to become transfers.
     :returns: Path relative to TS Location of the new transfer
     """
     # Get sorted list from source dir
@@ -199,33 +200,36 @@ def get_next_transfer(ss_url, ts_location_uuid, path_prefix, depth, completed):
     browse_info = _call_url_json(url, params)
     if browse_info is None:
         return None
-    dirs = browse_info['directories']
-    dirs = [base64.b64decode(d.encode('utf8')) for d in dirs]
-    LOGGER.debug('Dirs: %s', dirs)
-    dirs = [os.path.join(path_prefix, d) for d in dirs]
+    if see_files:
+        entries = browse_info['entries']
+    else:
+        entries = browse_info['directories']
+    entries = [base64.b64decode(e.encode('utf8')) for e in entries]
+    LOGGER.debug('Entries: %s', entries)
+    entries = [os.path.join(path_prefix, e) for e in entries]
     # If at the correct depth, check if any of these have not been made into transfers yet
     if depth <= 1:
         # Find the directories that are not already in the DB using sets
-        dirs = set(dirs) - completed
-        LOGGER.debug("New transfer candidates: %s", dirs)
+        entries = set(entries) - completed
+        LOGGER.debug("New transfer candidates: %s", entries)
         # Sort, take the first
-        dirs = sorted(list(dirs))
-        if not dirs:
+        entries = sorted(list(entries))
+        if not entries:
             LOGGER.info("All potential transfers in %s have been created.", path_prefix)
             return None
-        target = dirs[0]
+        target = entries[0]
         return target
     else:  # if depth > 1
         # Recurse on each directory
-        for d in dirs:
-            LOGGER.debug('New path: %s', d)
-            target = get_next_transfer(ss_url, ts_location_uuid, d, depth - 1, completed)
+        for e in entries:
+            LOGGER.debug('New path: %s', e)
+            target = get_next_transfer(ss_url, ts_location_uuid, e, depth - 1, completed, see_files)
             if target:
                 return target
     return None
 
 
-def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, api_key, transfer_type, session):
+def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, api_key, transfer_type, see_files, session):
     """
     Starts a new transfer.
 
@@ -236,12 +240,13 @@ def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, 
     :param am_url: URL of Archivematica pipeline to start transfer on
     :param user_name: User on Archivematica for authentication
     :param api_key: API key for user on Archivematica for authentication
+    :param bool see_files: If true, start transfers from files as well as directories
     :param session: SQLAlchemy session with the DB
     :returns: Tuple of Transfer information about the new transfer or None on error.
     """
     # Start new transfer
     completed = {x[0] for x in session.query(Unit.path).all()}
-    target = get_next_transfer(ss_url, ts_location_uuid, ts_path, depth, completed)
+    target = get_next_transfer(ss_url, ts_location_uuid, ts_path, depth, completed, see_files)
     if not target:
         LOGGER.warning("All potential transfers in %s have been created. Exiting", ts_path)
         return None
@@ -338,7 +343,7 @@ def approve_transfer(directory_name, url, api_key, user_name):
     else:
         return None
 
-def main(user, api_key, ts_uuid, ts_path, depth, am_url, ss_url, transfer_type):
+def main(user, api_key, ts_uuid, ts_path, depth, am_url, ss_url, transfer_type, see_files):
     LOGGER.info("Waking up")
     session = Session()
 
@@ -403,7 +408,7 @@ def main(user, api_key, ts_uuid, ts_path, depth, am_url, ss_url, transfer_type):
     # If failed, rejected, completed etc, start new transfer
     if current_unit:
         current_unit.current = False
-    new_transfer = start_transfer(ss_url, ts_uuid, ts_path, depth, am_url, user, api_key, transfer_type, session)
+    new_transfer = start_transfer(ss_url, ts_uuid, ts_path, depth, am_url, user, api_key, transfer_type, see_files, session)
 
     session.commit()
     os.remove(pid_file)
@@ -420,7 +425,7 @@ if __name__ == '__main__':
     parser.add_argument('--am-url', '-a', metavar='URL', help='Archivematica URL. Default: http://127.0.0.1', default='http://127.0.0.1')
     parser.add_argument('--ss-url', '-s', metavar='URL', help='Storage Service URL. Default: http://127.0.0.1:8000', default='http://127.0.0.1:8000')
     parser.add_argument('--transfer-type', metavar='TYPE', help="Type of transfer to start. One of: 'standard' (default), 'unzipped bag', 'zipped bag', 'dspace'.", default='standard', choices=['standard', 'unzipped bag', 'zipped bag', 'dspace'])
-    parser.add_argument('--files', action='store_true', help='Start transfers from files as well as folders. Unimplemented.')
+    parser.add_argument('--files', action='store_true', help='If set, start transfers from files as well as folders.')
     args = parser.parse_args()
 
     sys.exit(main(
@@ -431,5 +436,6 @@ if __name__ == '__main__':
         depth=args.depth,
         am_url=args.am_url,
         ss_url=args.ss_url,
-        transfer_type=args.transfer_type
+        transfer_type=args.transfer_type,
+        see_files=args.files,
     ))


### PR DESCRIPTION
* Specify transfer type as a parameter
* Allow creating transfers from files
* Add script to move files to a directory of the same name, to support other pre-transfer microservices (eg adding processingMCP)