### PR TITLE
Automate Transfers: Fix 'user' param to 'username'

### DIFF
--- a/fixtures/vcr_cassettes/get_status_ingest.yaml
+++ b/fixtures/vcr_cassettes/get_status_ingest.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-23-generic]
     method: GET
-    uri: http://127.0.0.1/api/ingest/status/f2248e2a-b593-43db-b60c-fa8513021785/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&user=demo
+    uri: http://127.0.0.1/api/ingest/status/f2248e2a-b593-43db-b60c-fa8513021785/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&username=demo
   response:
     body: {string: !!python/unicode '{"status": "USER_INPUT", "name": "test1", "microservice":
         "Normalize", "directory": "test1-f2248e2a-b593-43db-b60c-fa8513021785", "path":

--- a/fixtures/vcr_cassettes/get_status_no_unit.yaml
+++ b/fixtures/vcr_cassettes/get_status_no_unit.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-23-generic]
     method: GET
-    uri: http://127.0.0.1/api/transfer/status/deadc0de-c0de-c0de-c0de-deadc0dec0de/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&user=demo
+    uri: http://127.0.0.1/api/transfer/status/deadc0de-c0de-c0de-c0de-deadc0dec0de/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&username=demo
   response:
     body: {string: !!python/unicode '{"message": "Cannot fetch unitTransfer with UUID
         deadc0de-c0de-c0de-c0de-deadc0dec0de", "type": "transfer", "error": true}'}

--- a/fixtures/vcr_cassettes/get_status_not_json.yaml
+++ b/fixtures/vcr_cassettes/get_status_not_json.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-23-generic]
     method: GET
-    uri: http://127.0.0.1/api/transfer/status/dfc8cf5f-b5b1-408c-88b1-34215964e9d6/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&user=demo
+    uri: http://127.0.0.1/api/transfer/status/dfc8cf5f-b5b1-408c-88b1-34215964e9d6/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&username=demo
   response:
     body:
       string: !!binary |

--- a/fixtures/vcr_cassettes/get_status_transfer.yaml
+++ b/fixtures/vcr_cassettes/get_status_transfer.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-23-generic]
     method: GET
-    uri: http://127.0.0.1/api/transfer/status/dfc8cf5f-b5b1-408c-88b1-34215964e9d6/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&user=demo
+    uri: http://127.0.0.1/api/transfer/status/dfc8cf5f-b5b1-408c-88b1-34215964e9d6/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&username=demo
   response:
     body: {string: !!python/unicode '{"status": "USER_INPUT", "name": "test1", "microservice":
         "Approve standard transfer", "directory": "test1", "path": "/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer/test1/",

--- a/fixtures/vcr_cassettes/get_status_transfer_to_ingest.yaml
+++ b/fixtures/vcr_cassettes/get_status_transfer_to_ingest.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-23-generic]
     method: GET
-    uri: http://127.0.0.1/api/transfer/status/dfc8cf5f-b5b1-408c-88b1-34215964e9d6/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&user=demo
+    uri: http://127.0.0.1/api/transfer/status/dfc8cf5f-b5b1-408c-88b1-34215964e9d6/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&username=demo
   response:
     body: {string: !!python/unicode '{"status": "COMPLETE", "name": "test1", "sip_uuid":
         "f2248e2a-b593-43db-b60c-fa8513021785", "microservice": "Move to SIP creation
@@ -32,7 +32,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.3 CPython/2.7.3 Linux/3.5.0-23-generic]
     method: GET
-    uri: http://127.0.0.1/api/ingest/status/f2248e2a-b593-43db-b60c-fa8513021785/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&user=demo
+    uri: http://127.0.0.1/api/ingest/status/f2248e2a-b593-43db-b60c-fa8513021785/?api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&username=demo
   response:
     body: {string: !!python/unicode '{"status": "USER_INPUT", "name": "test1", "microservice":
         "Normalize", "directory": "test1-f2248e2a-b593-43db-b60c-fa8513021785", "path":

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -110,7 +110,7 @@ def get_status(am_url, user, api_key, unit_uuid, unit_type, session):
     """
     # Get status
     url = am_url + '/api/' + unit_type + '/status/' + unit_uuid + '/'
-    params = {'user': user, 'api_key': api_key}
+    params = {'username': user, 'api_key': api_key}
     unit_info = _call_url_json(url, params)
 
     # If Transfer is complete, get the SIP's status
@@ -256,7 +256,7 @@ def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, 
     LOGGER.info("Accession ID: %s", accession)
     # Start transfer
     url = am_url + '/api/transfer/start_transfer/'
-    params = {'user': user_name, 'api_key': api_key}
+    params = {'username': user_name, 'api_key': api_key}
     target_name = os.path.basename(target)
     data = {
         'name': target_name,


### PR DESCRIPTION
API auth actually checks the 'username' parameter, not 'user'.