### PR TITLE
Automate transfers: handle no accession id script

### DIFF
--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import os
 import unittest
 
 from sqlalchemy import create_engine
@@ -86,6 +86,10 @@ class TestAutomateTransfers(unittest.TestCase):
         transfer_uuid = 'dfc8cf5f-b5b1-408c-88b1-34215964e9d6'
         info = transfer.get_status(AM_URL, USER, API_KEY, transfer_uuid, 'transfer', session)
         assert info is None
+
+    def test_get_accession_id_no_script(self):
+        accession_id = transfer.get_accession_id(os.path.curdir)
+        assert accession_id is None
 
     @vcr.use_cassette('fixtures/vcr_cassettes/get_next_transfer_first_run.yaml')
     def test_get_next_transfer_first_run(self):

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -156,7 +156,11 @@ def get_accession_id(dirname):
     :returns: accession number or None.
     """
     script_path = os.path.join(THIS_DIR, 'get-accession-number')
-    p = subprocess.Popen([script_path, dirname], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        p = subprocess.Popen([script_path, dirname], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        LOGGER.info('%s does not exist.', script_path)
+        return None
     output, err = p.communicate()
     if p.returncode != 0:
         LOGGER.info('Error running %s %s: RC: %s; stdout: %s; stderr: %s', script_path, dirname, p.returncode, output, err)
@@ -296,7 +300,7 @@ def start_transfer(ss_url, ts_location_uuid, ts_path, depth, am_url, user_name, 
         return None
     if not response.ok or resp_json.get('error'):
         LOGGER.error('Unable to start transfer.')
-        LOGGER.debug('Response: %s', resp_json)
+        LOGGER.error('Response: %s', resp_json)
         new_transfer = Unit(path=target, unit_type='transfer', status='FAILED', current=False)
         session.add(new_transfer)
         return None


### PR DESCRIPTION
Since there's no default get-accession-id script anymore, this shouldn't error if one doesn't exist.