### PR TITLE
transfers: add config file for log/db/pid file paths

### DIFF
--- a/etc/transfer-script.sh
+++ b/etc/transfer-script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# transfer script example
+# /etc/archivematica/automation-tools/transfer-script.sh
+cd /usr/lib/archivematica/automation-tools/
+/usr/share/python/automation-tools/bin/python -m transfers.transfer --user <user>  --api-key <apikey> --transfer-source <transfer_source_uuid> --config-file <config_file>

--- a/etc/transfers-2.conf
+++ b/etc/transfers-2.conf
@@ -1,0 +1,7 @@
+# automation-tools:transfers configuration file example
+# /etc/archivematica/automation-tools/transfers-2.conf
+
+[transfers]
+logfile = /var/log/archivematica/automation-tools/transfers-2.log
+databasefile = /var/archivematica/automation-tools/transfers-2.db
+pidfile = /var/archivematica/automation-tools/transfers-2-pid.lck

--- a/etc/transfers.conf
+++ b/etc/transfers.conf
@@ -1,0 +1,7 @@
+# automation-tools:transfers configuration file example
+# /etc/archivematica/automation-tools/transfers.conf
+
+[transfers]
+logfile = /var/log/archivematica/automation-tools/transfers.log
+databasefile = /var/archivematica/automation-tools/transfers.db
+pidfile = /var/archivematica/automation-tools/transfers-pid.lck

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 requests<3.0
 sqlalchemy
+six

--- a/transfers/models.py
+++ b/transfers/models.py
@@ -1,16 +1,11 @@
-import os
-
 from sqlalchemy import create_engine
 from sqlalchemy import Sequence
 from sqlalchemy import Column, Binary, Boolean, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-db_path = os.path.join(os.path.dirname(__file__), 'transfers.db')
-engine = create_engine('sqlite:///{}'.format(db_path), echo=False)
-
-Session = sessionmaker(bind=engine)
 Base = declarative_base()
+
 
 class Unit(Base):
     __tablename__ = 'unit'
@@ -25,4 +20,9 @@ class Unit(Base):
     def __repr__(self):
         return "<Unit(id={s.id}, uuid={s.uuid}, unit_type={s.unit_type}, path={s.path}, status={s.status}, current={s.current})>".format(s=self)
 
-Base.metadata.create_all(engine)
+
+def init(databasefile):
+    engine = create_engine('sqlite:///{}'.format(databasefile), echo=False)
+    global Session
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)


### PR DESCRIPTION
Avoid creating log/db/pid files in the code path:
- Make models.py and transfer.py find config information in file
  /etc/archivematica/automation-tools/automation-tools.conf
- Provide example config files in etc/ directory