### PR TITLE
transfers: add_metadata hook writes csv

### DIFF
--- a/transfers/examples/pre-transfer/add_metadata.py
+++ b/transfers/examples/pre-transfer/add_metadata.py
@@ -2,29 +2,33 @@
 
 from __future__ import print_function
 
-import json
+import csv
 import os
 import sys
 
 def main(transfer_path):
+    if not os.path.isdir(transfer_path):
+        return 1
+    transfer_path = transfer_path.rstrip('/')
     basename = os.path.basename(transfer_path)
     try:
         dc_id, _, _ = basename.split('---')
     except ValueError:
+        print('Error splitting', basename)
         return 1
     print('Identifier: ', dc_id, end='')
     metadata = [
-        {
-            'parts': 'objects',
-            'dc.identifier': dc_id,
-        }
+        ['parts', 'dc.identifier'],
+        ['objects', dc_id]
     ]
     metadata_path = os.path.join(transfer_path, 'metadata')
     if not os.path.exists(metadata_path):
         os.makedirs(metadata_path)
-    metadata_path = os.path.join(metadata_path, 'metadata.json')
+    metadata_path = os.path.join(metadata_path, 'metadata.csv')
     with open(metadata_path, 'w') as f:
-        json.dump(metadata, f)
+        csvwriter = csv.writer(f)
+        csvwriter.writerows(metadata)
+
     return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
add_metadata example hook writes a metadata.csv instead of a metadata.json. Not all paths correctly handle metadata.json, so this will reduce problems with other types.
