### PR TITLE
FIX creation of database

### DIFF
--- a/transfers/models.py
+++ b/transfers/models.py
@@ -1,3 +1,5 @@
+from os.path import isfile
+
 from sqlalchemy import create_engine
 from sqlalchemy import Sequence
 from sqlalchemy import Column, Binary, Boolean, Integer, String
@@ -22,6 +24,10 @@ class Unit(Base):
 
 
 def init(databasefile):
+    if not isfile(databasefile):
+        # We create the file
+        with open(databasefile, "a"):
+            pass
     engine = create_engine('sqlite:///{}'.format(databasefile), echo=False)
     global Session
     Session = sessionmaker(bind=engine)


### PR DESCRIPTION
First time you run the automation-tools, the database file need to be created.

Currently, you'll have an error saying that it is impossible to open the file.

This fix will create the file if it doesn't exist. In case it is not possible to create it (permission), the standard error (access denied) will be shown.
