### PR TITLE
Create dips.atom_upload module and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The Automation Tools project is a set of python scripts, that are designed to au
   - [Configuration](#configuration-1)
     - [Parameters](#parameters-1)
     - [Getting Storage Service API key](#getting-storage-service-api-key)
+- [DIP upload to AtoM](#dip-upload-to-atom)
+  - [Configuration](#configuration-2)
+    - [Parameters](#parameters-2)
 - [Related Projects](#related-projects)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -261,6 +264,53 @@ The `aips/create_dip.py` accepts the following parameters:
 #### Getting Storage Service API key
 
 See [Getting API keys](#getting-api-keys)
+
+DIP upload to AtoM
+------------------
+
+`dips/atom_upload.py` is available to upload a DIP folder from the local filesystem to an external AtoM instance. It requires a passwordless SSH connection to the AtoM host for the user running the script and the AtoM host has to be already added to list of known hosts. [More info](https://wiki.archivematica.org/Upload_DIP#Send_your_DIPs_using_rsync)
+
+Although this script is part of the automation-tools it's not completely automated yet, so it needs to be executed once per DIP and it requires the DIP path and the AtoM target description slug.
+
+### Configuration
+
+Suggested use of this script is by using the example shell script in the `etc` directory (`/etc/archivematica/automation-tools/atom_upload_script.sh`):
+
+```
+#!/bin/bash
+cd /usr/lib/archivematica/automation-tools/
+/usr/share/python/automation-tools/bin/python -m dips.atom_upload \
+  --atom-url <url> \
+  --atom-email <email> \
+  --atom-password <password> \
+  --atom-slug <slug> \
+  --rsync-target <host:path> \
+  --dip-path <path> \
+  --log-file <path>
+```
+
+(Note that the script calls the upload to AtoM script as a module using python's `-m` flag, this is required due to the use of relative imports in the code)
+
+The script can be run from a shell window like:
+
+```
+user@host:/etc/archivematica/automation-tools$ sudo -u archivematica ./atom_upload_script.sh
+```
+
+#### Parameters
+
+The `dips/atom_upload.py` accepts the following parameters:
+
+* `--atom-url URL`: AtoM URL. Default: http://192.168.168.193
+* `--atom-email EMAIL` [REQUIRED]: Email of the AtoM user to authenticate as.
+* `--atom-password PASSWORD` [REQUIRED]: Password of the AtoM user to authenticate as.
+* `--atom-slug SLUG` [REQUIRED]: Slug of the AtoM archival description to target in the upload.
+* `--rsync-target HOST:PATH`: Host and path to place the DIP folder with `rsync`. Default: 192.168.168.193:/tmp
+* `--dip-path PATH` [REQUIRED]: Absolute path to a local DIP to upload.
+* `--log-file PATH`: Absolute path to a file to output the logs. Otherwise it will be created in the script directory.
+* `-v, --verbose`: Increase the debugging output. Can be specified multiple times, e.g. `-vv`
+* `-q, --quiet`: Decrease the debugging output. Can be specified multiple times, e.g. `-qq`
+* `--log-level`: Set the level for debugging output. One of: 'ERROR', 'WARNING', 'INFO', 'DEBUG'. This will override `-q` and `-v`
 
 Related Projects
 ----------------

--- a/dips/atom_upload.py
+++ b/dips/atom_upload.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+"""
+Uploads a DIP to AtoM
+
+Sends the DIP to the AtoM host using rsync and executes a deposit request to the
+AtoM instance. A passwordless SSH connection is required to the AtoM host for the
+user running this script and it must be already added to the list of known hosts.
+"""
+
+import argparse
+import logging
+import logging.config  # Has to be imported separately
+import os
+import subprocess
+import sys
+
+import requests
+
+
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+LOGGER = logging.getLogger('atom_upload')
+
+
+def setup_logger(log_file, log_level='INFO'):
+    """Configures the logger to output to console and log file"""
+    if not log_file:
+        log_file = os.path.join(THIS_DIR, 'atom_upload.log')
+
+    CONFIG = {
+        'version': 1,
+        'disable_existing_loggers': True,
+        'formatters': {
+            'default': {
+                'format': '%(levelname)-8s  %(asctime)s  %(message)s',
+                'datefmt': '%Y-%m-%d %H:%M:%S',
+            },
+        },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'default',
+            },
+            'file': {
+                'class': 'logging.handlers.RotatingFileHandler',
+                'formatter': 'default',
+                'filename': log_file,
+                'backupCount': 2,
+                'maxBytes': 10 * 1024,
+            },
+        },
+        'loggers': {
+            'atom_upload': {
+                'level': log_level,
+                'handlers': ['console', 'file'],
+            },
+        },
+    }
+
+    logging.config.dictConfig(CONFIG)
+
+
+def main(atom_url, atom_email, atom_password, atom_slug, rsync_target, dip_path):
+    """Sends the DIP to the AtoM host and a deposit request to the AtoM instance"""
+    LOGGER.info('Starting DIP upload to AtoM from: %s', dip_path)
+
+    try:
+        rsync(rsync_target, dip_path)
+    except subprocess.CalledProcessError as e:
+        LOGGER.error('Rsync ended unexpectedly: %s', e.output)
+        return 1
+
+    LOGGER.info('DIP folder sent to: %s', rsync_target)
+
+    try:
+        deposit(atom_url, atom_email, atom_password, atom_slug, dip_path)
+    except Exception as e:
+        LOGGER.error('Deposit request to AtoM failed: %s', e)
+        return 2
+
+    LOGGER.info('DIP deposited in AtoM')
+
+
+def rsync(rsync_target, dip_path):
+    """
+    Build and launch rsync command.
+
+    :param str rsync_target: host and path target for rsync
+    :param str dip_path: absolute path to the folder to rsync
+    :returns: None
+    """
+    command = ['rsync', '--protect-args', '-rltz', '-P', '--chmod=ugo=rwX', dip_path, rsync_target]
+    subprocess.check_output(command, stderr=subprocess.STDOUT)
+
+
+def deposit(atom_url, atom_email, atom_password, atom_slug, dip_path):
+    """
+    Generate and make deposit request to AtoM.
+
+    :param str atom_url: URL to the AtoM instance
+    :param str atom_email: AtoM user email
+    :param str atom_password: AtoM user password
+    :param str atom_slug: target AtoM arch. description slug
+    :param str dip_path: absolute path to a DIP folder
+    :raises Exception: if the AtoM response is not expected
+    :returns: None
+    """
+    # Build headers dictionary for the deposit request
+    headers = {}
+    headers['User-Agent'] = 'Archivematica'
+    headers['X-Packaging'] = 'http://purl.org/net/sword-types/METSArchivematicaDIP'
+    headers['Content-Type'] = 'application/zip'
+    headers['X-No-Op'] = 'false'
+    headers['X-Verbose'] = 'false'
+    headers['Content-Location'] = 'file:///{}'.format(os.path.basename(dip_path))
+
+    # Build URL and auth
+    url = '{}/sword/deposit/{}'.format(atom_url, atom_slug)
+    auth = requests.auth.HTTPBasicAuth(atom_email, atom_password)
+
+    # Make request (disable redirects)
+    LOGGER.info('Making deposit request to: %s', url)
+    response = requests.request('POST', url, auth=auth, headers=headers, allow_redirects=False)
+
+    # AtoM returns 302 instead of 202, but Location header field is valid
+    LOGGER.debug('Response code: %s', response.status_code)
+    LOGGER.debug('Response location: %s', response.headers.get('Location'))
+    LOGGER.debug('Response content:\n%s', response.content)
+
+    # Check response status code
+    if response.status_code not in [200, 201, 202, 302]:
+        raise Exception('Response status code not expected')
+
+    # Location is a must, if it is not included something went wrong
+    if response.headers.get('Location') is None:
+        raise Exception('Location header is missing in the response')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--atom-url', metavar='URL', help='AtoM instance URL. Default: http://192.168.168.193', default='http://192.168.168.193')
+    parser.add_argument('--atom-email', metavar='EMAIL', required=True, help='Email of the AtoM user to authenticate as.')
+    parser.add_argument('--atom-password', metavar='PASSWORD', required=True, help='Password of the AtoM user.')
+    parser.add_argument('--atom-slug', metavar='SLUG', required=True, help='AtoM archival description slug to target the upload.')
+    parser.add_argument('--rsync-target', metavar='HOST:PATH', help='Destination value passed to Rsync. Default: 192.168.168.193:/tmp.', default='192.168.168.193:/tmp')
+    parser.add_argument('--dip-path', metavar='PATH', required=True, help='Absolute path to the DIP to upload.')
+
+    # Logging
+    parser.add_argument('--log-file', metavar='FILE', help='Location of log file', default=None)
+    parser.add_argument('--verbose', '-v', action='count', default=0, help='Increase the debugging output.')
+    parser.add_argument('--quiet', '-q', action='count', default=0, help='Decrease the debugging output')
+    parser.add_argument('--log-level', choices=['ERROR', 'WARNING', 'INFO', 'DEBUG'], default=None, help='Set the debugging output level. This will override -q and -v')
+
+    args = parser.parse_args()
+
+    log_levels = {
+        2: 'ERROR',
+        1: 'WARNING',
+        0: 'INFO',
+        -1: 'DEBUG',
+    }
+    if args.log_level is None:
+        level = args.quiet - args.verbose
+        level = max(level, -1)  # No smaller than -1
+        level = min(level, 2)  # No larger than 2
+        log_level = log_levels[level]
+    else:
+        log_level = args.log_level
+
+    setup_logger(args.log_file, log_level)
+
+    sys.exit(main(
+        atom_url=args.atom_url,
+        atom_email=args.atom_email,
+        atom_password=args.atom_password,
+        atom_slug=args.atom_slug,
+        rsync_target=args.rsync_target,
+        dip_path=args.dip_path
+    ))

--- a/etc/atom_upload_script.sh
+++ b/etc/atom_upload_script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# atom_upload script example
+# /etc/archivematica/automation-tools/atom_upload_script.sh
+cd /usr/lib/archivematica/automation-tools/
+/usr/share/python/automation-tools/bin/python -m dips.atom_upload \
+  --atom-url <url> \
+  --atom-email <email> \
+  --atom-password <password> \
+  --atom-slug <slug> \
+  --rsync-target <host:path> \
+  --dip-path <path> \
+  --log-file <path>

--- a/fixtures/vcr_cassettes/deposit_fail.yaml
+++ b/fixtures/vcr_cassettes/deposit_fail.yaml
@@ -1,0 +1,27 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic YmFkQGVtYWlsLmNvbTpkZW1v]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Location: ['file:///fake_DIP']
+      Content-Type: [application/zip]
+      User-Agent: [Archivematica]
+      X-No-Op: ['false']
+      X-Packaging: ['http://purl.org/net/sword-types/METSArchivematicaDIP']
+      X-Verbose: ['false']
+    method: POST
+    uri: http://192.168.168.193/sword/deposit/test
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      connection: [keep-alive]
+      content-type: [text/html]
+      date: ['Wed, 06 Dec 2017 18:46:05 GMT']
+      server: [nginx]
+      www-authenticate: [Basic realm="Secure area"]
+    status: {code: 401, message: Unauthorized}
+version: 1

--- a/fixtures/vcr_cassettes/deposit_success.yaml
+++ b/fixtures/vcr_cassettes/deposit_success.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic ZGVtb0BleGFtcGxlLmNvbTpkZW1v]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Location: ['file:///fake_DIP']
+      Content-Type: [application/zip]
+      User-Agent: [Archivematica]
+      X-No-Op: ['false']
+      X-Packaging: ['http://purl.org/net/sword-types/METSArchivematicaDIP']
+      X-Verbose: ['false']
+    method: POST
+    uri: http://192.168.168.193/sword/deposit/test
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\" ?><entry\
+        \ xmlns=\"http://www.w3.org/2005/Atom\"\n       xmlns:sword=\"http://purl.org/net/sword/\"\
+        >\n\n  <title>test</title>\n\n  \n  <id>439 / 2017-11-30T02:47:10</id>\n\n\
+        \  <updated>2017-11-30T02:47:10</updated>\n  <author>\n    <name>demo</name>\n\
+        \  </author>\n\n  <generator uri=\"http://192.168.168.193/\" version=\"2.4.0\"\
+        >Qubit 2.4.0</generator>\n\n  <content type=\"text/html\" src=\"http://192.168.168.193/test\"\
+        \ />\n\n  <sword:noOp>false</sword:noOp>\n\n  <sword:packaging>http://purl.org/net/sword-types/METSArchivematicaDIP</sword:packaging>\n\
+        \n  <sword:userAgent>Archivematica</sword:userAgent>\n\n  \n</entry>\n"}
+    headers:
+      cache-control: [private]
+      connection: [keep-alive]
+      content-type: [text/xml; charset="utf-8"]
+      date: ['Wed, 06 Dec 2017 18:41:44 GMT']
+      location: [/test]
+      server: [nginx]
+      set-cookie: ['symfony=34c64df5d7ca27051add42c8b6ba5e30:69d5ae9bc2aac268be09749a7b419f6747da10f0;
+          expires=Fri, 05-Jan-2018 18:41:44 GMT; Max-Age=2592000; path=/; httponly']
+      x-ua-compatible: ['IE=edge,chrome=1']
+    status: {code: 302, message: Moved Temporarily}
+version: 1

--- a/tests/test_atom_upload.py
+++ b/tests/test_atom_upload.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+import subprocess
+import unittest
+import vcr
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from dips import atom_upload
+
+ATOM_URL = 'http://192.168.168.193'
+ATOM_EMAIL = 'demo@example.com'
+ATOM_PASSWORD = 'demo'
+ATOM_SLUG = 'test'
+RSYNC_TARGET = '192.168.168.193:/tmp'
+DIP_PATH = '/tmp/fake_DIP'
+
+
+class TestAtomUpload(unittest.TestCase):
+    def test_rsync_fail(self):
+        effect = subprocess.CalledProcessError(1, [])
+        with mock.patch('subprocess.check_output', side_effect=effect):
+            self.assertRaises(subprocess.CalledProcessError,
+                              atom_upload.rsync, RSYNC_TARGET, DIP_PATH)
+
+    def test_rsync_success(self):
+        with mock.patch('subprocess.check_output', return_value=None):
+            ret = atom_upload.rsync(RSYNC_TARGET, DIP_PATH)
+
+        assert ret is None
+
+    @vcr.use_cassette('fixtures/vcr_cassettes/deposit_fail.yaml')
+    def test_deposit_fail(self):
+        self.assertRaises(
+            Exception,
+            atom_upload.deposit,
+            ATOM_URL,
+            'bad@email.com',
+            ATOM_PASSWORD,
+            ATOM_SLUG,
+            DIP_PATH
+        )
+
+    @vcr.use_cassette('fixtures/vcr_cassettes/deposit_success.yaml')
+    def test_deposit_success(self):
+        ret = atom_upload.deposit(
+            ATOM_URL,
+            ATOM_EMAIL,
+            ATOM_PASSWORD,
+            ATOM_SLUG,
+            DIP_PATH
+        )
+
+        assert ret is None
+
+    def test_main_rsync_fail(self):
+        effect = subprocess.CalledProcessError(1, [])
+        with mock.patch('dips.atom_upload.rsync', side_effect=effect):
+            ret = atom_upload.main(
+                ATOM_URL,
+                ATOM_EMAIL,
+                ATOM_PASSWORD,
+                ATOM_SLUG,
+                RSYNC_TARGET,
+                DIP_PATH
+            )
+
+        assert ret == 1
+
+    def test_main_deposit_fail(self):
+        rsync_success = mock.patch('dips.atom_upload.rsync', return_value=None)
+        deposit_fail = mock.patch('dips.atom_upload.deposit',
+                                  side_effect=Exception(''))
+        with rsync_success, deposit_fail:
+            ret = atom_upload.main(
+                ATOM_URL,
+                ATOM_EMAIL,
+                ATOM_PASSWORD,
+                ATOM_SLUG,
+                RSYNC_TARGET,
+                DIP_PATH
+            )
+
+        assert ret == 2
+
+    def test_main_success(self):
+        rsync_success = mock.patch('dips.atom_upload.rsync', return_value=None)
+        deposit_success = mock.patch('dips.atom_upload.deposit',
+                                     return_value=None)
+        with rsync_success, deposit_success:
+            ret = atom_upload.main(
+                ATOM_URL,
+                ATOM_EMAIL,
+                ATOM_PASSWORD,
+                ATOM_SLUG,
+                RSYNC_TARGET,
+                DIP_PATH
+            )
+
+        assert ret is None


### PR DESCRIPTION
Sends the DIP to the AtoM host using rsync and executes a deposit request to the
AtoM instance. A passwordless SSH connection is required to the AtoM host for the
user running this script and it must be already added to the list of known hosts.