### PR TITLE
Improvement: add "whitelist" for script file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The `transfers.py` script can be modified to adjust how automated transfers work
 * `-q, --quiet`: Decrease the debugging output. Can be specified multiple times, e.g. `-qq`
 * `--log-level`: Set the level for debugging output. One of: 'ERROR', 'WARNING', 'INFO', 'DEBUG'. This will override `-q` and `-v`
 
+The `--config-file` specified can also be used to define a list of file extensions that script files should have for execution. By default there is no limitation, but it may be useful to specify this, for example `scriptextensions = .py:.sh`. Multiple extensions may be specified, using '`:`' as a separator.
+
 #### Getting Correct UUIDs and Setting Processing Rules
 
 The easiest way to configure the tasks that automation-tools will run is by using the dashboard:

--- a/etc/transfers.conf
+++ b/etc/transfers.conf
@@ -5,3 +5,4 @@
 logfile = /var/log/archivematica/automation-tools/transfers.log
 databasefile = /var/archivematica/automation-tools/transfers.db
 pidfile = /var/archivematica/automation-tools/transfers-pid.lck
+scriptextensions = .py:.sh

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -213,7 +213,7 @@ def run_scripts(directory, *args):
     LOGGER.debug('script_args: %s', script_args)
     for script in sorted(os.listdir(directory)):
         LOGGER.debug('Script: %s', script)
-        script_path = os.path.join(directory, script)
+        script_path = os.path.realpath(os.path.join(directory, script))
         if not os.path.isfile(script_path):
             LOGGER.info('%s is not a file, skipping', script)
             continue


### PR DESCRIPTION
The `run_scripts` function in `transfer.py` is currently very trusting in terms of what it should execute. It uses the execute bit in the file mode to determine if something is executable, and assumes it should be executed if this is set. Aside from the obvious security concern about executing user-contributed code, it also falls foul of the execution bit being set incorrectly, e.g. by some well-meaning recursive `chmod 777` etc. In particular, we have found that XML files with the executable bit set are considered for execution, which consequently fails.

This pull request improves the way that `run_scripts` works by adding a `script_extensions` whitelist that files should have before being considered executable by the code. This is configurable using the `scriptextensions` parameter in the config file. By default it is set to an empty list, meaning that all executable files are executed (retaining the current behaviour), but setting it to `.py:.sh` will cause any files that don't have a `.py` or `.sh` extension to be ignored and not considered for execution. This satisfies our use case, causing XML files that are "executable" to be ignored.

In addition, I've added some error handling to the `start_transfer` function. Previously, any error encountered in the call to `run_scripts` when processing files in the `pre-transfer` folder was not handled, and caused the entire `transfer.py` process to crash out, leaving its pid lock file in place and preventing any further executions to occur. Errors in the `run_scripts` call are now caught, and reported via the logger, before returning cleanly and allowing the pid lock file to be cleaned up before the process completes.

Lastly, this pull request includes a previous commit from @jhsimpson to make the `run_scripts` function look at the target of symlinks, using the `realpath` of the file rather than its source path. This was believed to be the reason why scripts were being considered for execution, but even if you follow the symlink then if the target file has its executable bit set then execution will still be attempted, hence the need for the `script_extensions` addition described above.
  