### PR TITLE
Add transfer_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Automation Tools project is a set of python scripts, that are designed to au
     - [user-input](#user-input)
   - [Logs](#logs)
   - [Multiple automated transfer instances](#multiple-automated-transfer-instances)
+  - [`transfer_async.py`](#transfer_asyncpy)
 - [DIP creation](#dip-creation)
   - [Configuration](#configuration-1)
     - [Parameters](#parameters-1)
@@ -218,6 +219,22 @@ You may need to set up multiple automated transfer instances, for example if req
 `<config_file_1>` and `<config_file_2>` should specify different file names for db/PID/log files. See transfers.conf and transfers-2.conf in etc/ for an example
 
 In case different hooks are required for each instance, a possible approach is to checkout a new instance of the automation tools, for example in `/usr/lib/archivematica/automation-tools-2`
+
+### `transfer_async.py`
+
+This is a new work-in-progress entry point similar to `transfers.transfer` that uses the new asynchronous endpoints of Archivematica being developed under the `/api/v2beta` API. It takes the same arguments, e.g.:
+
+```
+#!/usr/bin/env bash
+
+cd /usr/lib/archivematica/automation-tools/
+
+/usr/share/python/automation-tools/bin/python -m transfers.transfer_async \
+  --user <user> --api-key <apikey> \
+  --ss-user <user> --ss-api-key <apikey> \
+  --transfer-source <transfer_source_uuid> \
+  --config-file <config_file>
+```
 
 DIP creation
 ------------

--- a/tests/test_amclient.py
+++ b/tests/test_amclient.py
@@ -9,8 +9,7 @@ import unittest
 
 import vcr
 
-from transfers import amclient
-from transfers import errors
+from transfers import amclient, errors
 
 
 AM_URL = 'http://192.168.168.192'

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -6,9 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 import vcr
 
-from transfers import errors
-from transfers import transfer
-from transfers import models
+from transfers import errors, transfer, models
 
 AM_URL = 'http://127.0.0.1'
 SS_URL = 'http://127.0.0.1:8000'

--- a/transfers/amclient.py
+++ b/transfers/amclient.py
@@ -27,11 +27,7 @@ import requests
 # by ensuring that it can see itself.
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from transfers import loggingconfig
-from transfers import defaults
-from transfers import amclientargs
-from transfers import errors
-from transfers import utils
+from transfers import loggingconfig, defaults, amclientargs, errors, utils
 
 LOGGER = logging.getLogger('transfers')
 
@@ -130,7 +126,7 @@ class AMClient(object):
                                      err_lookup(errors.ERR_CLIENT_UNKNOWN)))
                 else:
                     self.stdout(getattr(self, method)())
-            except:
+            except BaseException:
                 self.stdout(errors.error_lookup(errors.ERR_CLIENT_UNKNOWN))
         else:
             raise AttributeError('AMClient has no method {0}'.format(name))

--- a/transfers/amclientargs.py
+++ b/transfers/amclientargs.py
@@ -8,8 +8,6 @@ from collections import namedtuple
 import os
 import sys
 
-from six import binary_type, text_type
-
 # AM Client Module Configuration.
 
 # Allow execution as an executable and the script to be run at package level
@@ -17,20 +15,8 @@ from six import binary_type, text_type
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from transfers import defaults
+from transfers.utils import fsencode
 
-try:
-    from os import fsencode
-except ImportError:
-    def fsencode(filename):
-        """Cribbed & modified from Python3's OS module to support Python2."""
-        encoding = sys.getfilesystemencoding()
-        if isinstance(filename, binary_type):
-            return filename
-        elif isinstance(filename, text_type):
-            return filename.encode(encoding)
-        else:
-            raise TypeError("expect bytes or str, not %s" %
-                            type(filename).__name__)
 
 # Reusable argument constants (for CLI).
 Arg = namedtuple('Arg', ['name', 'help', 'type'])

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -24,11 +24,7 @@ from six.moves import configparser
 # by ensuring that it can see itself.
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from transfers import defaults
-from transfers import errors
-from transfers import loggingconfig
-from transfers import models
-from transfers import utils
+from transfers import defaults, errors, loggingconfig, models, utils
 from transfers.transferargs import get_parser
 from transfers.utils import fsencode, fsdecode
 
@@ -415,7 +411,7 @@ def main(am_user, am_api_key, ss_user, ss_api_key, ts_uuid, ts_path, depth,
         # Open PID file only if it doesn't exist for read/write
         f = os.fdopen(
             os.open(pid_file, os.O_CREAT | os.O_EXCL | os.O_RDWR), 'r+')
-    except:
+    except BaseException:
         LOGGER.info('This script is already running. To override this '
                     'behaviour and start a new run, remove %s', pid_file)
         return 0

--- a/transfers/transfer_async.py
+++ b/transfers/transfer_async.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Automate Transfers.
+
+Helper script to automate running transfers through Archivematica.
+
+Similar to ``transfers.transfer`` but using the new `/api/v2beta` API when
+possible.
+"""
+
+from __future__ import print_function, unicode_literals
+
+import base64
+import os
+import sys
+
+import requests
+
+# Allow execution as an executable and the script to be run at package level
+# by ensuring that it can see itself.
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from transfers import transfer
+from transfers.loggingconfig import set_log_level
+from transfers.models import Unit
+from transfers.transferargs import get_parser
+from transfers.transfer import (
+    LOGGER, get_next_transfer, get_accession_id, main
+)
+from transfers.utils import fsencode
+
+
+class DashboardAPIError(Exception):
+    """Dashboard API error."""
+
+
+def _api_create_package(am_url, am_user, am_api_key,
+                        name, type, accession,
+                        ts_location_uuid, ts_path):
+    url = am_url + '/api/v2beta/package/'
+    headers = {
+        'Authorization': 'ApiKey {}:{}'.format(am_user, am_api_key)
+    }
+    data = {
+        'name': name,
+        'type': type,
+        'accession': accession,
+        'path': base64.b64encode(fsencode(ts_location_uuid) + b':' + ts_path),
+    }
+    LOGGER.debug('URL: %s; Headers: %s, Data: %s', url, headers, data)
+    response = requests.post(url, headers=headers, json=data)
+    response.raise_for_status()
+    LOGGER.debug('Response: %s', response)
+    resp_json = response.json()
+    error = resp_json.get('error')
+    if error:
+        raise DashboardAPIError(error)
+    return resp_json
+
+
+def _start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path,
+                    depth, am_url, am_user, am_api_key, transfer_type,
+                    see_files, session, config_file):
+    """
+    Start a new transfer.
+
+    This is an early implementation and an alternative to
+    ``transfer.start_transfer`` that uses the new ``/api/v2beta/package`` API.
+    Because transfers start immediately we don't run the scripts inside the
+    pre-transfer directory like ``transfer.start_transfer`` does.
+
+    :param ss_url: URL of the Storage Sevice to query
+    :param ss_user: User on the Storage Service for authentication
+    :param ss_api_key: API key for user on the Storage Service for
+                       authentication
+    :param ts_location_uuid: UUID of the transfer source Location
+    :param ts_path: Relative path inside the Location to work with.
+    :param depth: Depth relative to ts_path to create a transfer from. Should
+                  be 1 or greater.
+    :param am_url: URL of Archivematica pipeline to start transfer on
+    :param am_user: User on Archivematica for authentication
+    :param am_api_key: API key for user on Archivematica for authentication
+    :param bool see_files: If true, start transfers from files as well as
+                           directories
+    :param session: SQLAlchemy session with the DB
+    :returns: Tuple of Transfer information about the new transfer or None on
+              error.
+    """
+    # Start new transfer
+    completed = {x[0] for x in session.query(Unit.path).all()}
+    target = get_next_transfer(
+        ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path, depth,
+        completed, see_files)
+    if not target:
+        LOGGER.warning(
+            "All potential transfers in %s have been created. Exiting",
+            ts_path)
+        return None
+    LOGGER.info("Starting with %s", target)
+    # Get accession ID
+    accession = get_accession_id(target)
+    LOGGER.info("Accession ID: %s", accession)
+
+    try:
+        result = _api_create_package(
+            am_url, am_user, am_api_key,
+            os.path.basename(target), transfer_type, accession,
+            ts_location_uuid, target,
+        )
+    except (requests.exceptions.HTTPError,
+            ValueError, DashboardAPIError) as err:
+        LOGGER.error('Unable to start transfer: %s', err)
+        new_transfer = Unit(
+            path=target, unit_type='transfer', status='FAILED', current=False)
+        session.add(new_transfer)
+        return None
+
+    # We don't run the scripts in the pre-transfer directory because the
+    # _api_create_package automatically starts the transfer.
+
+    LOGGER.info('Package created: %s', result['id'])
+    new_transfer = Unit(
+        uuid=result['id'], path=target, unit_type='transfer', current=True)
+    LOGGER.info('New transfer: %s', new_transfer)
+    session.add(new_transfer)
+
+    return new_transfer
+
+
+if __name__ == '__main__':
+    parser = get_parser(__doc__)
+    args = parser.parse_args()
+
+    # Override ``start_transfer`` function.
+    transfer.start_transfer = _start_transfer
+
+    sys.exit(main(
+        am_user=args.user,
+        am_api_key=args.api_key,
+        ss_user=args.ss_user,
+        ss_api_key=args.ss_api_key,
+        ts_uuid=args.transfer_source,
+        ts_path=args.transfer_path,
+        depth=args.depth,
+        am_url=args.am_url,
+        ss_url=args.ss_url,
+        transfer_type=args.transfer_type,
+        see_files=args.files,
+        hide_on_complete=args.hide,
+        config_file=args.config_file,
+        log_level=set_log_level(args.log_level, args.quiet, args.verbose),
+    ))

--- a/transfers/transfer_async.py
+++ b/transfers/transfer_async.py
@@ -37,7 +37,7 @@ class DashboardAPIError(Exception):
 
 
 def _api_create_package(am_url, am_user, am_api_key,
-                        name, type, accession,
+                        name, package_type, accession,
                         ts_location_uuid, ts_path):
     url = am_url + '/api/v2beta/package/'
     headers = {
@@ -45,7 +45,7 @@ def _api_create_package(am_url, am_user, am_api_key,
     }
     data = {
         'name': name,
-        'type': type,
+        'type': package_type,
         'accession': accession,
         'path': base64.b64encode(fsencode(ts_location_uuid) + b':' + ts_path),
     }
@@ -62,7 +62,7 @@ def _api_create_package(am_url, am_user, am_api_key,
 
 def _start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path,
                     depth, am_url, am_user, am_api_key, transfer_type,
-                    see_files, session, config_file):
+                    see_files, session):
     """
     Start a new transfer.
 
@@ -117,9 +117,6 @@ def _start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path,
         session.add(new_transfer)
         return None
 
-    # We don't run the scripts in the pre-transfer directory because the
-    # _api_create_package automatically starts the transfer.
-
     LOGGER.info('Package created: %s', result['id'])
     new_transfer = Unit(
         uuid=result['id'], path=target, unit_type='transfer', current=True)
@@ -149,6 +146,5 @@ if __name__ == '__main__':
         transfer_type=args.transfer_type,
         see_files=args.files,
         hide_on_complete=args.hide,
-        config_file=args.config_file,
         log_level=set_log_level(args.log_level, args.quiet, args.verbose),
     ))

--- a/transfers/transferargs.py
+++ b/transfers/transferargs.py
@@ -1,0 +1,73 @@
+import argparse
+
+from transfers.defaults import DEF_AM_URL, DEF_SS_URL
+from transfers.utils import fsencode
+
+
+def get_parser(doc):
+    # Variable for conformance to flake8 line lenght below.
+    rawformatter = argparse.RawDescriptionHelpFormatter
+
+    parser = argparse.ArgumentParser(description=doc,
+                                     formatter_class=rawformatter)
+    parser.add_argument('-u', '--user', metavar='USERNAME', required=True,
+                        help='Username of the Archivematica dashboard user '
+                              'to authenticate as.')
+    parser.add_argument('-k', '--api-key', metavar='KEY',
+                        required=True, help='API key of the Archivematica '
+                                            'dashboard user.')
+    parser.add_argument('--ss-user', metavar='USERNAME', required=True,
+                        help='Username of the Storage Service user to '
+                             'authenticate as.')
+    parser.add_argument('--ss-api-key', metavar='KEY',
+                        required=True, help='API key of the Storage Service '
+                                            'user.')
+    parser.add_argument(
+        '-t', '--transfer-source', metavar='UUID', required=True,
+        help='Transfer Source Location UUID to fetch transfers from.')
+    parser.add_argument(
+        # default=b'' to convert to bytes from unicode str provided by
+        # command line.
+        '--transfer-path', metavar='PATH', help='Relative path within the '
+                                                'Transfer Source. Default: ""',
+                                                type=fsencode, default=b'')
+    parser.add_argument(
+        '--depth', '-d', help='Depth to create the transfers from relative '
+                              'to the transfer source location and path. '
+                              'Default of 1 creates transfers from the '
+                              'children of transfer-path.', type=int,
+        default=1)
+    parser.add_argument('--am-url', '-a', metavar='URL',
+                        help='Archivematica URL. Default: %s' % DEF_AM_URL,
+                        default='%s' % DEF_AM_URL)
+    parser.add_argument('--ss-url', '-s', metavar='URL',
+                        help='Storage Service URL. Default: %s' % DEF_SS_URL,
+                        default='%s' % DEF_SS_URL)
+    parser.add_argument(
+        '--transfer-type', metavar='TYPE', help="Type of transfer to start. "
+                                                "One of: 'standard' "
+                                                "(default), 'unzipped bag', "
+                                                "'zipped bag', 'dspace'.",
+        default='standard', choices=['standard', 'unzipped bag',
+                                     'zipped bag', 'dspace'])
+    parser.add_argument('--files', action='store_true',
+                        help='If set, start transfers from files as well as '
+                             'folders.')
+    parser.add_argument('--hide', action='store_true',
+                        help='If set, hide the Transfers and SIPs in the '
+                             'dashboard once they complete.')
+    parser.add_argument('-c', '--config-file', metavar='FILE',
+                        help='Configuration file(log/db/PID files)',
+                        default=None)
+
+    # Logging
+    parser.add_argument('--verbose', '-v', action='count',
+                        default=0, help='Increase the debugging output.')
+    parser.add_argument('--quiet', '-q', action='count',
+                        default=0, help='Decrease the debugging output')
+    parser.add_argument(
+        '--log-level', choices=['ERROR', 'WARNING', 'INFO', 'DEBUG'],
+        default=None, help='Set the debugging output level. This will '
+                           'override -q and -v')
+
+    return parser

--- a/transfers/transferargs.py
+++ b/transfers/transferargs.py
@@ -1,3 +1,5 @@
+"""Command-line argument parser for automated transfer scripts."""
+
 import argparse
 
 from transfers.defaults import DEF_AM_URL, DEF_SS_URL
@@ -5,6 +7,7 @@ from transfers.utils import fsencode
 
 
 def get_parser(doc):
+    """Parser comand-line arguments for automated transfer scripts."""
     # Variable for conformance to flake8 line lenght below.
     rawformatter = argparse.RawDescriptionHelpFormatter
 
@@ -12,7 +15,7 @@ def get_parser(doc):
                                      formatter_class=rawformatter)
     parser.add_argument('-u', '--user', metavar='USERNAME', required=True,
                         help='Username of the Archivematica dashboard user '
-                              'to authenticate as.')
+                             'to authenticate as.')
     parser.add_argument('-k', '--api-key', metavar='KEY',
                         required=True, help='API key of the Archivematica '
                                             'dashboard user.')
@@ -28,9 +31,10 @@ def get_parser(doc):
     parser.add_argument(
         # default=b'' to convert to bytes from unicode str provided by
         # command line.
-        '--transfer-path', metavar='PATH', help='Relative path within the '
-                                                'Transfer Source. Default: ""',
-                                                type=fsencode, default=b'')
+        '--transfer-path',
+        metavar='PATH', help='Relative path within the '
+                             'Transfer Source. Default: ""',
+        type=fsencode, default=b'')
     parser.add_argument(
         '--depth', '-d', help='Depth to create the transfers from relative '
                               'to the transfer source location and path. '

--- a/transfers/utils.py
+++ b/transfers/utils.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 
+"""Where you put stuff when you can't think of a good name for a module."""
+
 import logging
+import sys
+
 import requests
 import urllib3
+from six import binary_type, text_type
 
 from transfers import errors
 
@@ -11,6 +16,7 @@ LOGGER = logging.getLogger('transfers')
 
 def _call_url_json(url, params, method='GET'):
     """Helper to GET a URL where the expected response is 200 with JSON.
+
     :param str url: URL to call
     :param dict params: Params to pass to requests.get
     :returns: Dict of the returned JSON or an integer error
@@ -42,3 +48,38 @@ def _call_url_json(url, params, method='GET'):
             requests.exceptions.ConnectionError) as err:
         LOGGER.error("Connection error %s", err)
         return errors.ERR_SERVER_CONN
+
+
+try:
+    from os import fsencode, fsdecode
+except ImportError:
+    # Cribbed & modified from Python3's OS module to support Python2
+    def fsencode(filename):
+        """Encode path-like filename to the filesystem encoding.
+
+        See https://docs.python.org/3/library/os.html#os.fsencode for more
+        details.
+        """
+        encoding = sys.getfilesystemencoding()
+        if isinstance(filename, binary_type):
+            return filename
+        elif isinstance(filename, text_type):
+            return filename.encode(encoding)
+        else:
+            raise TypeError("expect bytes or str, not %s" %
+                            type(filename).__name__)
+
+    def fsdecode(filename):
+        """Decode the path-like filename from the filesystem encoding.
+
+        See https://docs.python.org/3/library/os.html#os.fsdecode for more
+        details.
+        """
+        encoding = sys.getfilesystemencoding()
+        if isinstance(filename, text_type):
+            return filename
+        elif isinstance(filename, binary_type):
+            return filename.decode(encoding)
+        else:
+            raise TypeError("expect bytes or str, not %s" %
+                            type(filename).__name__)


### PR DESCRIPTION
`transfer_async.py` is an entry point that reuses what's in `transfer.py` but hijacks the only function that needed to be changed (`start_transfer`) so the script works against the new `/api/v2beta/package` API.

`transfer_async.py` does not run `pre-transfer` scripts because the transfers are started automatically so there is no room for that. In the future, `/api/v2beta/package` may learn a new `open` status that may allow us to solve this limitation.

This can be considered a walking skeleton. The plan is to eventually have it replace `transfer.py`. The advantage is that `/api/v2beta/package` does not block. This was a priority @ JiscRDSS because you can't have a connection open for hours like we do when we're copying big transfers - `/api/v2beta/package` solves that problem.

I've been testing in my Compose environment and the following command:

```
python -m transfers.transfer_async \
    --log-level DEBUG \
    --user test --api-key test --am-url http://127.0.0.1:62080 \
    --ss-user test --ss-api-key test --ss-url http://127.0.0.1:62081 \
    --transfer-source "b002cea4-82cf-4bc5-b4e5-fbc87443540d" \
    --transfer-path /home/test \
    --transfer-type standard
```

Issue: https://jiscdev.atlassian.net/browse/RDSSARK-480.
It depends on https://github.com/artefactual/archivematica/pull/936.