### PR TITLE
Allow a logger to be passed to utils as an arg

### DIFF
--- a/transfers/defaults.py
+++ b/transfers/defaults.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Defaults and constants for amclient.py and transfers.py

--- a/transfers/errors.py
+++ b/transfers/errors.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ERR_INVALID_RESPONSE = 1

--- a/transfers/loggingconfig.py
+++ b/transfers/loggingconfig.py
@@ -1,18 +1,16 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import logging
 import logging.config  # Has to be imported separately
 
 
-def setup(log_level, log_file_name, log_name):
-
+def setup(log_level, log_file_name):
+    """Configure the logging system."""
     # Log format string for flake8 compliance
-    log_fmt = ('%(levelname)-8s  %(asctime)s%(filename)s:%(lineno)-4s '
-               '%(message)s')
+    log_fmt = ('%(levelname)-8s  %(asctime)s '
+               '%(filename)s:%(lineno)-4s %(message)s')
 
-    # Configure logging
-    CONFIG = {
+    dict_config = {
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
@@ -32,16 +30,13 @@ def setup(log_level, log_file_name, log_name):
                 'filename': log_file_name,
                 'backupCount': 2,
                 'maxBytes': 10 * 1024,
+                'delay': True,  # Ony write to file on first byte emitted.
             },
         },
         'loggers': {
-            'transfer': {
+            'transfers': {
                 'level': log_level,
                 'handlers': ['console', 'file'],
-            },
-            'amclient': {
-                'level': log_level,
-                'handlers': ['file'],
             },
             'requests.packages.urllib3': {
                 'level': log_level,
@@ -50,9 +45,7 @@ def setup(log_level, log_file_name, log_name):
         },
     }
 
-    LOGGER = logging.getLogger(log_name)
-    logging.config.dictConfig(CONFIG)
-    return LOGGER
+    logging.config.dictConfig(dict_config)
 
 
 def set_log_level(log_level, quiet, verbose):

--- a/transfers/utils.py
+++ b/transfers/utils.py
@@ -1,20 +1,12 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
 import requests
 import urllib3
 
-from transfers import defaults
-from transfers import loggingconfig
 from transfers import errors
 
-
-def get_logger(log_file_name, log_level):
-    return loggingconfig.setup(log_level, log_file_name, "amclient")
-
-
-# Default logging if no other logging is provided in the class.
-LOGGER = get_logger(defaults.AMCLIENT_LOG_FILE, defaults.DEFAULT_LOG_LEVEL)
+LOGGER = logging.getLogger('transfers')
 
 
 def _call_url_json(url, params, method='GET'):
@@ -47,6 +39,6 @@ def _call_url_json(url, params, method='GET'):
             return errors.ERR_PARSE_JSON
 
     except (urllib3.exceptions.NewConnectionError,
-            requests.exceptions.ConnectionError) as e:
-        LOGGER.error("Connection error %s", e)
+            requests.exceptions.ConnectionError) as err:
+        LOGGER.error("Connection error %s", err)
         return errors.ERR_SERVER_CONN


### PR DESCRIPTION
The refactor in 699b018 didn't fully take into account the how logging
might work across the module. Python provides module level thread safe
logging at the module level through the logging module with appropriate
configuration.

This fix provides that functionality and additionaly sets a delay write
flag to ensure that no logs are created when there is no logging information
output.

Fixes #51
Resolves #52

Shebangs have been removed from non-executable scripts to resolve #55

Minor pylint changes added. Importantly, the incorrect check against a
non-existent ERR_AMCLIENT_UNKNOWN has been replaced with ERR_CLIENT_UNKNOWN.

--

Thanks to @sevein for his guidance on how to use the logging module effectively. 