### PR TITLE
Adds AM Client Capability in support of Reingest

### DIFF
--- a/fixtures/vcr_cassettes/approve_existing_transfer.yaml
+++ b/fixtures/vcr_cassettes/approve_existing_transfer.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: !!python/unicode directory=approve_1&type=standard
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192/api/transfer/approve/
+  response:
+    body: {string: !!python/unicode '{"message": "Approval successful.", 
+        "uuid": "5ad38ce3-27e5-4211-a0b5-eb70f13d28fa"}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 08 Apr 2018 17:13:06 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/approve_non_existing_transfer.yaml
+++ b/fixtures/vcr_cassettes/approve_non_existing_transfer.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: !!python/unicode directory=approve_1&type=standard
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192/api/transfer/approve/
+  response:
+    body: {string: !!python/unicode '{"message": "Unable to find unapproved transfer
+        directory.", "error": true}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 08 Apr 2018 07:02:56 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 500, message: INTERNAL SERVER ERROR}
+version: 1

--- a/fixtures/vcr_cassettes/pipeline.yaml
+++ b/fixtures/vcr_cassettes/pipeline.yaml
@@ -1,0 +1,27 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/pipeline/
+  response:
+    body: {string: !!python/unicode '{"meta": {"limit": 20, "next": null,
+        "offset": 0, "previous": null, "total_count": 1}, 
+        "objects": [{"description": "Archivematica on ff4c2e051a31", 
+        "remote_name": "172.18.0.13", "resource_uri": 
+        "/api/v2/pipeline/f914af05-c7d2-4611-b2eb-61cd3426d9d2/", 
+        "uuid": "f914af05-c7d2-4611-b2eb-61cd3426d9d2"}]}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/pipeline_none.yaml
+++ b/fixtures/vcr_cassettes/pipeline_none.yaml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/pipeline/
+  response:
+    body: {string: !!python/unicode '{"meta": {"limit": 20, "next": null, 
+        "offset": 0, "previous": null, "total_count": 0}, "objects": []}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/reingest_exsting_aip.yaml
+++ b/fixtures/vcr_cassettes/reingest_exsting_aip.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: !!python/unicode '{"pipeline": "65aaac5d-b4fd-478e-967b-6cdfee02f2c5", "reingest_type":
+      "full", "processing_config": "default"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['109']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/file/df8e0c68-3bda-4d1d-8493-789f7dec47f5/reingest/
+  response:
+    body: {string: !!python/unicode '{"error": false, "message": "Package df8e0c68-3bda-4d1d-8493-789f7dec47f5
+        sent to pipeline Archivematica on 4e2f66a7a29f (65aaac5d-b4fd-478e-967b-6cdfee02f2c5)
+        for re-ingest", "reingest_uuid": "9dac7039-b0d8-4185-b27e-af008a9687ac", "status_code":
+        202}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 08 Apr 2018 18:58:35 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept, Accept-Language, Cookie']
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 202, message: ACCEPTED}
+version: 1

--- a/fixtures/vcr_cassettes/reingest_non_existing_aip.yaml
+++ b/fixtures/vcr_cassettes/reingest_non_existing_aip.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: !!python/unicode '{"pipeline": "bb033eff-131e-48d5-980f-c4edab0cb038", "reingest_type":
+      "full", "processing_config": "default"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['109']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/file/bb033eff-131e-48d5-980f-c4edab0cb038/reingest/
+  response:
+    body: {string: !!python/unicode Resource with UUID bb033eff-131e-48d5-980f-c4edab0cb038
+        does not exist}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [text/html; charset=utf-8]
+      date: ['Sun, 08 Apr 2018 07:17:17 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept, Accept-Language, Cookie']
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fixtures/vcr_cassettes/test_get_existing_processing_config.yaml
+++ b/fixtures/vcr_cassettes/test_get_existing_processing_config.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192/api/processing-configuration/default
+  response:
+    body: {string: !!python/unicode "<processingMCP>\n  <preconfiguredChoices>\n    <!--
+        Select compression level -->\n    <preconfiguredChoice>\n      <appliesTo>01c651cb-c174-4ba4-b985-1d87a44d6754</appliesTo>\n
+        \     <goToChain>ecfad581-b007-4612-a0e0-fcc551f4057f</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Select file format identification command (Submission documentation
+        & metadata) -->\n    <preconfiguredChoice>\n      <appliesTo>087d27be-c719-47d8-9bbb-9a7d8b609c44</appliesTo>\n
+        \     <goToChain>25a91595-37f0-4373-a89a-56a757353fb8</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Select compression algorithm -->\n    <preconfiguredChoice>\n      <appliesTo>01d64f58-8295-4b7b-9cab-8f1b153a504f</appliesTo>\n
+        \     <goToChain>9475447c-9889-430c-9477-6287a9574c5b</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Delete packages after extraction -->\n    <preconfiguredChoice>\n
+        \     <appliesTo>f19926dd-8fb5-4c79-8ade-c83f61f55b40</appliesTo>\n      <goToChain>85b1e45d-8f98-4cae-8336-72f40e12cbef</goToChain>\n
+        \   </preconfiguredChoice>\n    <!-- Select file format identification command
+        (Ingest) -->\n    <preconfiguredChoice>\n      <appliesTo>7a024896-c4f7-4808-a240-44c87c762bc5</appliesTo>\n
+        \     <goToChain>3c1faec7-7e1e-4cdd-b3bd-e2f05f4baa9b</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Send transfer to quarantine -->\n    <preconfiguredChoice>\n      <appliesTo>755b4177-c587-41a7-8c52-015277568302</appliesTo>\n
+        \     <goToChain>d4404ab1-dc7f-4e9e-b1f8-aa861e766b8e</goToChain>\n    </preconfiguredChoice>\n
+        \ </preconfiguredChoices>\n</processingMCP>\n"}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [text/xml]
+      date: ['Sun, 08 Apr 2018 07:18:52 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/test_get_non_existing_processing_config.yaml
+++ b/fixtures/vcr_cassettes/test_get_non_existing_processing_config.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192/api/processing-configuration/badf00d
+  response:
+    body: {string: !!python/unicode "\n<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n
+        \ <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n
+        \ <title>Page not found at /api/processing-configuration/badf00d</title>\n
+        \ <meta name=\"robots\" content=\"NONE,NOARCHIVE\">\n  <style type=\"text/css\">\n
+        \   html * { padding:0; margin:0; }\n    body * { padding:10px 20px; }\n    body
+        * * { padding:0; }\n    body { font:small sans-serif; background:#eee; }\n
+        \   body>div { border-bottom:1px solid #ddd; }\n    h1 { font-weight:normal;
+        margin-bottom:.4em; }\n    h1 span { font-size:60%; color:#666; font-weight:normal;
+        }\n    table { border:none; border-collapse: collapse; width:100%; }\n    td,
+        th { vertical-align:top; padding:2px 3px; }\n    th { width:12em; text-align:right;
+        color:#666; padding-right:.5em; }\n    #info { background:#f6f6f6; }\n    #info
+        ol { margin: 0.5em 4em; }\n    #info ol li { font-family: monospace; }\n    #summary
+        { background: #ffc; }\n    #explanation { background:#eee; border-bottom:
+        0px none; }\n  </style>\n</head>\n<body>\n  <div id=\"summary\">\n    <h1>Page
+        not found <span>(404)</span></h1>\n    <table class=\"meta\">\n      <tr>\n
+        \       <th>Request Method:</th>\n        <td>GET</td>\n      </tr>\n      <tr>\n
+        \       <th>Request URL:</th>\n        <td>http://127.0.0.1:62080/api/processing-configuration/badf00d</td>\n
+        \     </tr>\n      \n      <tr>\n        <th>Raised by:</th>\n        <td>components.api.views.wrapper</td>\n
+        \     </tr>\n      \n    </table>\n  </div>\n  <div id=\"info\">\n    \n      <p></p>\n
+        \   \n  </div>\n\n  <div id=\"explanation\">\n    <p>\n      You're seeing
+        this error because you have <code>DEBUG = True</code> in\n      your Django
+        settings file. Change that to <code>False</code>, and Django\n      will display
+        a standard 404 page.\n    </p>\n  </div>\n</body>\n</html>\n"}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [text/html]
+      date: ['Sun, 08 Apr 2018 07:17:16 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fixtures/vcr_cassettes/transfer_status.yaml
+++ b/fixtures/vcr_cassettes/transfer_status.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192/api/transfer/status/63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9/
+  response:
+    body: {string: !!python/unicode '{"status": "COMPLETE", 
+        "name": "transfer_test_1", "sip_uuid": "BACKLOG", "microservice": 
+        "Create placement in backlog PREMIS events", "directory": 
+        "transfer_test_1-63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9", 
+        "path": "/var/archivematica/sharedDirectory/watchedDirectories/SIPCreation/completedTransfers/transfer_test_1-63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9/", 
+        "message": "Fetched status for 63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9 successfully.", 
+        "type": "transfer", "uuid": "63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9"}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/transfer_status_invalid_uuid.yaml
+++ b/fixtures/vcr_cassettes/transfer_status_invalid_uuid.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192/api/transfer/status/7bffc8f7-baad-f00d-8120-b1c51c2ab5db/
+  response:
+    body: {string: !!python/unicode '{"message": 
+        "Cannot fetch unitTransfer with UUID 7bffc8f7-baad-f00d-8120-b1c51c2ab5db", 
+        "type": "transfer", "error": true}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/transfers/models.py
+++ b/transfers/models.py
@@ -20,8 +20,9 @@ class Unit(Base):
     current = Column(Boolean(create_constraint=False))
 
     def __repr__(self):
-        return "<Unit(id={s.id}, uuid={s.uuid}, unit_type={s.unit_type}, \
-        path={s.path}, status={s.status}, current={s.current})>".format(s=self)
+        return ("<Unit(id={s.id}, uuid={s.uuid}, unit_type={s.unit_type}, "
+                "path={s.path}, status={s.status}, current={s.current})>"
+                .format(s=self))
 
 
 def init(databasefile):


### PR DESCRIPTION
This PR adds capability to AM Client in support of the API functions
required for automated reingest.

* Adds new functions to AM Client, including reingest and transfer status.
* Provides unit testing for the additional function calls.
* Extends utils.py request mechanism to enable http authentication headers
  to be set.
* A formatting issue was discovered in models.py while testing which
  is now corrected.

Submitted as part of Redmine ticket 11686 for CCA in support of automated reingest, cc. @timothyryanwalsh.  