### PR TITLE
Adds AM Client Capability in support of Reingest

### DIFF
--- a/fixtures/vcr_cassettes/approve_existing_transfer.yaml
+++ b/fixtures/vcr_cassettes/approve_existing_transfer.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: !!python/unicode directory=approve_1&type=standard
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192/api/transfer/approve/
+  response:
+    body: {string: !!python/unicode '{"message": "Approval successful.", 
+        "uuid": "5ad38ce3-27e5-4211-a0b5-eb70f13d28fa"}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 08 Apr 2018 17:13:06 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/approve_non_existing_transfer.yaml
+++ b/fixtures/vcr_cassettes/approve_non_existing_transfer.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: !!python/unicode directory=approve_1&type=standard
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['33']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192/api/transfer/approve/
+  response:
+    body: {string: !!python/unicode '{"message": "Unable to find unapproved transfer
+        directory.", "error": true}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 08 Apr 2018 07:02:56 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 500, message: INTERNAL SERVER ERROR}
+version: 1

--- a/fixtures/vcr_cassettes/close_completed_ingests_ingests.yaml
+++ b/fixtures/vcr_cassettes/close_completed_ingests_ingests.yaml
@@ -5,19 +5,19 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      User-Agent: [python-requests/2.18.1]
     method: GET
     uri: http://192.168.168.192/api/ingest/completed?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
   response:
-    body: {string: !!python/unicode '{"message": "Fetched completed ingests successfully.",
-        "results": ["66391111-0dba-4236-877f-b61cda71cf23", "88394649-3d72-491b-9742-c5e673bf80e0"]}'}
+    body: {string: '{"message": "Fetched completed ingests successfully.", "results":
+        ["2d75323c-70a0-4d5f-a8d0-762e729fc2b9", "57d7faff-c397-4485-9035-6eaeb5c35636"]}'}
     headers:
-      connection: [Keep-Alive]
-      content-type: [application/json]
-      date: ['Mon, 02 Jan 2017 21:34:15 GMT']
-      keep-alive: ['timeout=5, max=100']
-      server: [Apache/2.4.7 (Ubuntu)]
-      vary: [Cookie]
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 May 2018 07:52:43 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -26,18 +26,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      User-Agent: [python-requests/2.18.1]
     method: DELETE
-    uri: http://192.168.168.192/api/ingest/66391111-0dba-4236-877f-b61cda71cf23/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
+    uri: http://192.168.168.192/api/ingest/2d75323c-70a0-4d5f-a8d0-762e729fc2b9/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
   response:
-    body: {string: !!python/unicode '{"removed": true}'}
+    body: {string: '{"removed": true}'}
     headers:
-      connection: [Keep-Alive]
-      content-type: [application/json]
-      date: ['Mon, 02 Jan 2017 21:34:15 GMT']
-      keep-alive: ['timeout=5, max=100']
-      server: [Apache/2.4.7 (Ubuntu)]
-      vary: [Cookie]
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 May 2018 07:52:43 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -46,17 +46,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      User-Agent: [python-requests/2.18.1]
     method: DELETE
-    uri: http://192.168.168.192/api/ingest/88394649-3d72-491b-9742-c5e673bf80e0/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
+    uri: http://192.168.168.192/api/ingest/57d7faff-c397-4485-9035-6eaeb5c35636/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
   response:
-    body: {string: !!python/unicode '{"removed": true}'}
+    body: {string: '{"removed": true}'}
     headers:
-      connection: [Keep-Alive]
-      content-type: [application/json]
-      date: ['Mon, 02 Jan 2017 21:34:15 GMT']
-      keep-alive: ['timeout=5, max=100']
-      server: [Apache/2.4.7 (Ubuntu)]
-      vary: [Cookie]
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 May 2018 07:52:44 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
     status: {code: 200, message: OK}
 version: 1

--- a/fixtures/vcr_cassettes/close_completed_transfers_transfers.yaml
+++ b/fixtures/vcr_cassettes/close_completed_transfers_transfers.yaml
@@ -5,19 +5,19 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.11.1]
+      User-Agent: [python-requests/2.18.1]
     method: GET
-    uri: http://192.168.168.192/api/transfer/completed?api_key=3c23b0361887ace72b9d42963d9acbdf06644673&username=test
+    uri: http://192.168.168.192/api/transfer/completed?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
   response:
     body: {string: '{"message": "Fetched completed transfers successfully.", "results":
-        ["26841c49-bed4-4db3-bf77-1bb0ac5db32c", "2f7bb26b-d1c7-484f-b41a-7e3f2fefa084"]}'}
+        ["9bc0b1c7-658f-46d4-9a6f-4a282e8a8ee5", "d7bd50b5-6473-4e9f-8555-8515e55d0a16"]}'}
     headers:
-      Connection: [Keep-Alive]
+      Connection: [keep-alive]
+      Content-Language: [en]
       Content-Type: [application/json]
-      Date: ['Mon, 07 Nov 2016 19:01:36 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Vary: [Cookie]
+      Date: ['Mon, 07 May 2018 08:00:02 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -26,18 +26,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python-requests/2.11.1]
+      User-Agent: [python-requests/2.18.1]
     method: DELETE
-    uri: http://192.168.168.192/api/transfer/26841c49-bed4-4db3-bf77-1bb0ac5db32c/delete/?api_key=3c23b0361887ace72b9d42963d9acbdf06644673&username=test
+    uri: http://192.168.168.192/api/transfer/9bc0b1c7-658f-46d4-9a6f-4a282e8a8ee5/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
   response:
     body: {string: '{"removed": true}'}
     headers:
-      Connection: [Keep-Alive]
+      Connection: [keep-alive]
+      Content-Language: [en]
       Content-Type: [application/json]
-      Date: ['Mon, 07 Nov 2016 19:01:36 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Vary: [Cookie]
+      Date: ['Mon, 07 May 2018 08:00:02 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -46,17 +46,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [python-requests/2.11.1]
+      User-Agent: [python-requests/2.18.1]
     method: DELETE
-    uri: http://192.168.168.192/api/transfer/2f7bb26b-d1c7-484f-b41a-7e3f2fefa084/delete/?api_key=3c23b0361887ace72b9d42963d9acbdf06644673&username=test
+    uri: http://192.168.168.192/api/transfer/d7bd50b5-6473-4e9f-8555-8515e55d0a16/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
   response:
     body: {string: '{"removed": true}'}
     headers:
-      Connection: [Keep-Alive]
+      Connection: [keep-alive]
+      Content-Language: [en]
       Content-Type: [application/json]
-      Date: ['Mon, 07 Nov 2016 19:01:36 GMT']
-      Keep-Alive: ['timeout=5, max=100']
-      Server: [Apache/2.4.7 (Ubuntu)]
-      Vary: [Cookie]
+      Date: ['Mon, 07 May 2018 08:00:02 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
     status: {code: 200, message: OK}
 version: 1

--- a/fixtures/vcr_cassettes/get_all_compressed_aips.yaml
+++ b/fixtures/vcr_cassettes/get_all_compressed_aips.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/file/?username=test&api_key=5de62f6f4817f903dcfac47fa5cffd44685a2cf2&package_type=AIP
+  response:
+    body: {string: '{"meta": {"limit": 20, "next": null, "offset": 0, "previous":
+        null, "total_count": 5}, "objects": [{"current_full_path": "/var/archivematica/sharedDirectory/watchedDirectories/storeAIP/5843/53f3/c402/4ff5/a00c/59d0/e133/4683/deleted_1-584353f3-c402-4ff5-a00c-59d0e1334683.7z",
+        "current_location": "/api/v2/location/022713c0-f298-4d74-90fb-eb17da38d44f/",
+        "current_path": "5843/53f3/c402/4ff5/a00c/59d0/e133/4683/deleted_1-584353f3-c402-4ff5-a00c-59d0e1334683.7z",
+        "encrypted": false, "misc_attributes": {"reingest_pipeline": null}, "origin_pipeline":
+        "/api/v2/pipeline/79120a48-974a-46eb-ac01-eee496e0f57f/", "package_type":
+        "AIP", "related_packages": [], "replicas": [], "replicated_package": null,
+        "resource_uri": "/api/v2/file/584353f3-c402-4ff5-a00c-59d0e1334683/", "size":
+        13284, "status": "DELETED", "uuid": "584353f3-c402-4ff5-a00c-59d0e1334683"},
+        {"current_full_path": "/var/archivematica/sharedDirectory/watchedDirectories/storeAIP/6f54/7b25/aea0/4161/9f68/316f/c246/5fd9/deleted_2-6f547b25-aea0-4161-9f68-316fc2465fd9.7z",
+        "current_location": "/api/v2/location/022713c0-f298-4d74-90fb-eb17da38d44f/",
+        "current_path": "6f54/7b25/aea0/4161/9f68/316f/c246/5fd9/deleted_2-6f547b25-aea0-4161-9f68-316fc2465fd9.7z",
+        "encrypted": false, "misc_attributes": {"reingest_pipeline": null}, "origin_pipeline":
+        "/api/v2/pipeline/79120a48-974a-46eb-ac01-eee496e0f57f/", "package_type":
+        "AIP", "related_packages": [], "replicas": [], "replicated_package": null,
+        "resource_uri": "/api/v2/file/6f547b25-aea0-4161-9f68-316fc2465fd9/", "size":
+        13277, "status": "DELETED", "uuid": "6f547b25-aea0-4161-9f68-316fc2465fd9"},
+        {"current_full_path": "/var/archivematica/sharedDirectory/watchedDirectories/storeAIP/6d32/a85f/6715/43af/947c/83c9/d7f0/deac/transfer_1-6d32a85f-6715-43af-947c-83c9d7f0deac.7z",
+        "current_location": "/api/v2/location/022713c0-f298-4d74-90fb-eb17da38d44f/",
+        "current_path": "6d32/a85f/6715/43af/947c/83c9/d7f0/deac/transfer_1-6d32a85f-6715-43af-947c-83c9d7f0deac.7z",
+        "encrypted": false, "misc_attributes": {}, "origin_pipeline": "/api/v2/pipeline/79120a48-974a-46eb-ac01-eee496e0f57f/",
+        "package_type": "AIP", "related_packages": [], "replicas": [], "replicated_package":
+        null, "resource_uri": "/api/v2/file/6d32a85f-6715-43af-947c-83c9d7f0deac/",
+        "size": 13230, "status": "UPLOADED", "uuid": "6d32a85f-6715-43af-947c-83c9d7f0deac"},
+        {"current_full_path": "/var/archivematica/sharedDirectory/watchedDirectories/storeAIP/6f19/8696/e3b6/4f45/8ab3/b4cd/4afd/921a/transfer_2-6f198696-e3b6-4f45-8ab3-b4cd4afd921a.7z",
+        "current_location": "/api/v2/location/022713c0-f298-4d74-90fb-eb17da38d44f/",
+        "current_path": "6f19/8696/e3b6/4f45/8ab3/b4cd/4afd/921a/transfer_2-6f198696-e3b6-4f45-8ab3-b4cd4afd921a.7z",
+        "encrypted": false, "misc_attributes": {}, "origin_pipeline": "/api/v2/pipeline/79120a48-974a-46eb-ac01-eee496e0f57f/",
+        "package_type": "AIP", "related_packages": [], "replicas": [], "replicated_package":
+        null, "resource_uri": "/api/v2/file/6f198696-e3b6-4f45-8ab3-b4cd4afd921a/",
+        "size": 13269, "status": "UPLOADED", "uuid": "6f198696-e3b6-4f45-8ab3-b4cd4afd921a"},
+        {"current_full_path": "/var/archivematica/sharedDirectory/watchedDirectories/storeAIP/9c5e/dcdc/3e3f/499d/a016/a43b/9db8/75b1/transfer_3-9c5edcdc-3e3f-499d-a016-a43b9db875b1.7z",
+        "current_location": "/api/v2/location/022713c0-f298-4d74-90fb-eb17da38d44f/",
+        "current_path": "9c5e/dcdc/3e3f/499d/a016/a43b/9db8/75b1/transfer_3-9c5edcdc-3e3f-499d-a016-a43b9db875b1.7z",
+        "encrypted": false, "misc_attributes": {}, "origin_pipeline": "/api/v2/pipeline/79120a48-974a-46eb-ac01-eee496e0f57f/",
+        "package_type": "AIP", "related_packages": [], "replicas": [], "replicated_package":
+        null, "resource_uri": "/api/v2/file/9c5edcdc-3e3f-499d-a016-a43b9db875b1/",
+        "size": 13236, "status": "UPLOADED", "uuid": "9c5edcdc-3e3f-499d-a016-a43b9db875b1"}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Thu, 03 May 2018 12:51:32 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept, Accept-Language, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/get_package_details.yaml
+++ b/fixtures/vcr_cassettes/get_package_details.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/file/23129471-09e3-467e-88b6-eb4714afb5ac
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      connection: [keep-alive]
+      content-language: [en-us]
+      content-type: [text/html; charset=utf-8]
+      date: ['Sun, 15 Apr 2018 14:05:58 GMT']
+      location: ['http://127.0.0.1:62081/api/v2/file/23129471-09e3-467e-88b6-eb4714afb5ac/']
+      server: [nginx/1.12.2]
+      vary: [Accept-Language]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 301, message: MOVED PERMANENTLY}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://127.0.0.1:62081/api/v2/file/23129471-09e3-467e-88b6-eb4714afb5ac/
+  response:
+    body: {string: !!python/unicode '{"current_full_path": "/var/archivematica/sharedDirectory/www/AIPsStore/2312/9471/09e3/467e/88b6/eb47/14af/b5ac/five-23129471-09e3-467e-88b6-eb4714afb5ac.7z",
+        "current_location": "/api/v2/location/b69754bb-3367-44f0-a00c-8eca0c0b53dd/",
+        "current_path": "2312/9471/09e3/467e/88b6/eb47/14af/b5ac/five-23129471-09e3-467e-88b6-eb4714afb5ac.7z",
+        "encrypted": false, "misc_attributes": {"reingest_pipeline": null}, "origin_pipeline":
+        "/api/v2/pipeline/cc3bf7dd-ab62-4e19-927e-6a5e196294e2/", "package_type":
+        "AIP", "related_packages": [], "replicas": [], "replicated_package": null,
+        "resource_uri": "/api/v2/file/23129471-09e3-467e-88b6-eb4714afb5ac/", "size":
+        19606, "status": "UPLOADED", "uuid": "23129471-09e3-467e-88b6-eb4714afb5ac"}'}
+    headers:
+      cache-control: [no-cache]
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 15 Apr 2018 14:05:58 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept, Accept-Language, Cookie']
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/get_package_details_invalid_uuid.yaml
+++ b/fixtures/vcr_cassettes/get_package_details_invalid_uuid.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/file/23129471-baad-f00d-88b6-eb4714afb5ac
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      connection: [keep-alive]
+      content-language: [en-us]
+      content-type: [text/html; charset=utf-8]
+      date: ['Sun, 15 Apr 2018 14:03:13 GMT']
+      location: ['http://127.0.0.1:62081/api/v2/file/23129471-baad-f00d-88b6-eb4714afb5ac/']
+      server: [nginx/1.12.2]
+      vary: [Accept-Language]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 301, message: MOVED PERMANENTLY}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://127.0.0.1:62081/api/v2/file/23129471-baad-f00d-88b6-eb4714afb5ac/
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [text/html; charset=utf-8]
+      date: ['Sun, 15 Apr 2018 14:03:13 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept, Accept-Language, Cookie']
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fixtures/vcr_cassettes/ingest_status.yaml
+++ b/fixtures/vcr_cassettes/ingest_status.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192/api/ingest/status/23129471-09e3-467e-88b6-eb4714afb5ac/
+  response:
+    body: {string: !!python/unicode '{"status": "COMPLETE", "name": "five", "microservice":
+        "Remove the processing directory", "directory": "five-23129471-09e3-467e-88b6-eb4714afb5ac",
+        "path": "/var/archivematica/sharedDirectory/currentlyProcessing/five-23129471-09e3-467e-88b6-eb4714afb5ac/",
+        "message": "Fetched status for 23129471-09e3-467e-88b6-eb4714afb5ac successfully.",
+        "type": "SIP", "uuid": "23129471-09e3-467e-88b6-eb4714afb5ac"}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 15 Apr 2018 13:41:55 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/ingest_status_invalid_uuid.yaml
+++ b/fixtures/vcr_cassettes/ingest_status_invalid_uuid.yaml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192/api/ingest/status/63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9/
+  response:
+    body: {string: !!python/unicode '{"message": "Cannot fetch unitSIP with UUID 63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9",
+        "type": "SIP", "error": true}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 15 Apr 2018 13:41:55 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 400, message: BAD REQUEST}
+version: 1

--- a/fixtures/vcr_cassettes/pipeline.yaml
+++ b/fixtures/vcr_cassettes/pipeline.yaml
@@ -1,0 +1,27 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/pipeline/
+  response:
+    body: {string: !!python/unicode '{"meta": {"limit": 20, "next": null,
+        "offset": 0, "previous": null, "total_count": 1}, 
+        "objects": [{"description": "Archivematica on ff4c2e051a31", 
+        "remote_name": "172.18.0.13", "resource_uri": 
+        "/api/v2/pipeline/f914af05-c7d2-4611-b2eb-61cd3426d9d2/", 
+        "uuid": "f914af05-c7d2-4611-b2eb-61cd3426d9d2"}]}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/pipeline_none.yaml
+++ b/fixtures/vcr_cassettes/pipeline_none.yaml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/pipeline/
+  response:
+    body: {string: !!python/unicode '{"meta": {"limit": 20, "next": null, 
+        "offset": 0, "previous": null, "total_count": 0}, "objects": []}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/reingest_exsting_aip.yaml
+++ b/fixtures/vcr_cassettes/reingest_exsting_aip.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: !!python/unicode '{"pipeline": "65aaac5d-b4fd-478e-967b-6cdfee02f2c5", "reingest_type":
+      "full", "processing_config": "default"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['109']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/file/df8e0c68-3bda-4d1d-8493-789f7dec47f5/reingest/
+  response:
+    body: {string: !!python/unicode '{"error": false, "message": "Package df8e0c68-3bda-4d1d-8493-789f7dec47f5
+        sent to pipeline Archivematica on 4e2f66a7a29f (65aaac5d-b4fd-478e-967b-6cdfee02f2c5)
+        for re-ingest", "reingest_uuid": "9dac7039-b0d8-4185-b27e-af008a9687ac", "status_code":
+        202}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Sun, 08 Apr 2018 18:58:35 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept, Accept-Language, Cookie']
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 202, message: ACCEPTED}
+version: 1

--- a/fixtures/vcr_cassettes/reingest_non_existing_aip.yaml
+++ b/fixtures/vcr_cassettes/reingest_non_existing_aip.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: !!python/unicode '{"pipeline": "bb033eff-131e-48d5-980f-c4edab0cb038", "reingest_type":
+      "full", "processing_config": "default"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      Content-Length: ['109']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/file/bb033eff-131e-48d5-980f-c4edab0cb038/reingest/
+  response:
+    body: {string: !!python/unicode Resource with UUID bb033eff-131e-48d5-980f-c4edab0cb038
+        does not exist}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [text/html; charset=utf-8]
+      date: ['Sun, 08 Apr 2018 07:17:17 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept, Accept-Language, Cookie']
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fixtures/vcr_cassettes/test_get_existing_processing_config.yaml
+++ b/fixtures/vcr_cassettes/test_get_existing_processing_config.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192/api/processing-configuration/default
+  response:
+    body: {string: !!python/unicode "<processingMCP>\n  <preconfiguredChoices>\n    <!--
+        Select compression level -->\n    <preconfiguredChoice>\n      <appliesTo>01c651cb-c174-4ba4-b985-1d87a44d6754</appliesTo>\n
+        \     <goToChain>ecfad581-b007-4612-a0e0-fcc551f4057f</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Select file format identification command (Submission documentation
+        & metadata) -->\n    <preconfiguredChoice>\n      <appliesTo>087d27be-c719-47d8-9bbb-9a7d8b609c44</appliesTo>\n
+        \     <goToChain>25a91595-37f0-4373-a89a-56a757353fb8</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Select compression algorithm -->\n    <preconfiguredChoice>\n      <appliesTo>01d64f58-8295-4b7b-9cab-8f1b153a504f</appliesTo>\n
+        \     <goToChain>9475447c-9889-430c-9477-6287a9574c5b</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Delete packages after extraction -->\n    <preconfiguredChoice>\n
+        \     <appliesTo>f19926dd-8fb5-4c79-8ade-c83f61f55b40</appliesTo>\n      <goToChain>85b1e45d-8f98-4cae-8336-72f40e12cbef</goToChain>\n
+        \   </preconfiguredChoice>\n    <!-- Select file format identification command
+        (Ingest) -->\n    <preconfiguredChoice>\n      <appliesTo>7a024896-c4f7-4808-a240-44c87c762bc5</appliesTo>\n
+        \     <goToChain>3c1faec7-7e1e-4cdd-b3bd-e2f05f4baa9b</goToChain>\n    </preconfiguredChoice>\n
+        \   <!-- Send transfer to quarantine -->\n    <preconfiguredChoice>\n      <appliesTo>755b4177-c587-41a7-8c52-015277568302</appliesTo>\n
+        \     <goToChain>d4404ab1-dc7f-4e9e-b1f8-aa861e766b8e</goToChain>\n    </preconfiguredChoice>\n
+        \ </preconfiguredChoices>\n</processingMCP>\n"}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [text/xml]
+      date: ['Sun, 08 Apr 2018 07:18:52 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/test_get_non_existing_processing_config.yaml
+++ b/fixtures/vcr_cassettes/test_get_non_existing_processing_config.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:test']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://192.168.168.192/api/processing-configuration/badf00d
+  response:
+    body: {string: !!python/unicode "\n<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n
+        \ <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n
+        \ <title>Page not found at /api/processing-configuration/badf00d</title>\n
+        \ <meta name=\"robots\" content=\"NONE,NOARCHIVE\">\n  <style type=\"text/css\">\n
+        \   html * { padding:0; margin:0; }\n    body * { padding:10px 20px; }\n    body
+        * * { padding:0; }\n    body { font:small sans-serif; background:#eee; }\n
+        \   body>div { border-bottom:1px solid #ddd; }\n    h1 { font-weight:normal;
+        margin-bottom:.4em; }\n    h1 span { font-size:60%; color:#666; font-weight:normal;
+        }\n    table { border:none; border-collapse: collapse; width:100%; }\n    td,
+        th { vertical-align:top; padding:2px 3px; }\n    th { width:12em; text-align:right;
+        color:#666; padding-right:.5em; }\n    #info { background:#f6f6f6; }\n    #info
+        ol { margin: 0.5em 4em; }\n    #info ol li { font-family: monospace; }\n    #summary
+        { background: #ffc; }\n    #explanation { background:#eee; border-bottom:
+        0px none; }\n  </style>\n</head>\n<body>\n  <div id=\"summary\">\n    <h1>Page
+        not found <span>(404)</span></h1>\n    <table class=\"meta\">\n      <tr>\n
+        \       <th>Request Method:</th>\n        <td>GET</td>\n      </tr>\n      <tr>\n
+        \       <th>Request URL:</th>\n        <td>http://127.0.0.1:62080/api/processing-configuration/badf00d</td>\n
+        \     </tr>\n      \n      <tr>\n        <th>Raised by:</th>\n        <td>components.api.views.wrapper</td>\n
+        \     </tr>\n      \n    </table>\n  </div>\n  <div id=\"info\">\n    \n      <p></p>\n
+        \   \n  </div>\n\n  <div id=\"explanation\">\n    <p>\n      You're seeing
+        this error because you have <code>DEBUG = True</code> in\n      your Django
+        settings file. Change that to <code>False</code>, and Django\n      will display
+        a standard 404 page.\n    </p>\n  </div>\n</body>\n</html>\n"}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [text/html]
+      date: ['Sun, 08 Apr 2018 07:17:16 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fixtures/vcr_cassettes/test_hide_units.yaml
+++ b/fixtures/vcr_cassettes/test_hide_units.yaml
@@ -1,0 +1,124 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.1]
+    method: DELETE
+    uri: http://192.168.168.192/api/transfer/fdf1f7d4-7b0e-46d7-a1cc-e1851f8b92ed/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
+  response:
+    body: {string: '{"removed": true}'}
+    headers:
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 May 2018 07:27:16 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.1]
+    method: DELETE
+    uri: http://192.168.168.192/api/transfer/777a9d9e-baad-f00d-8c7e-00b75773672d/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
+  response:
+    body: {string: "\n<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta http-equiv=\"content-type\"
+        content=\"text/html; charset=utf-8\">\n  <title>Page not found at /api/transfer/777a9d9e-baad-f00d-8c7e-00b75773672d/delete/</title>\n
+        \ <meta name=\"robots\" content=\"NONE,NOARCHIVE\">\n  <style type=\"text/css\">\n
+        \   html * { padding:0; margin:0; }\n    body * { padding:10px 20px; }\n    body
+        * * { padding:0; }\n    body { font:small sans-serif; background:#eee; }\n
+        \   body>div { border-bottom:1px solid #ddd; }\n    h1 { font-weight:normal;
+        margin-bottom:.4em; }\n    h1 span { font-size:60%; color:#666; font-weight:normal;
+        }\n    table { border:none; border-collapse: collapse; width:100%; }\n    td,
+        th { vertical-align:top; padding:2px 3px; }\n    th { width:12em; text-align:right;
+        color:#666; padding-right:.5em; }\n    #info { background:#f6f6f6; }\n    #info
+        ol { margin: 0.5em 4em; }\n    #info ol li { font-family: monospace; }\n    #summary
+        { background: #ffc; }\n    #explanation { background:#eee; border-bottom:
+        0px none; }\n  </style>\n</head>\n<body>\n  <div id=\"summary\">\n    <h1>Page
+        not found <span>(404)</span></h1>\n    <table class=\"meta\">\n      <tr>\n
+        \       <th>Request Method:</th>\n        <td>DELETE</td>\n      </tr>\n      <tr>\n
+        \       <th>Request URL:</th>\n        <td>http://192.168.168.192/api/transfer/777a9d9e-baad-f00d-8c7e-00b75773672d/delete/?username=test&amp;api_key=3c23b0361887ace72b9d42963d9acbdf06644673</td>\n
+        \     </tr>\n      \n      <tr>\n        <th>Raised by:</th>\n        <td>components.api.views.wrapper</td>\n
+        \     </tr>\n      \n    </table>\n  </div>\n  <div id=\"info\">\n    \n      <p></p>\n
+        \   \n  </div>\n\n  <div id=\"explanation\">\n    <p>\n      You're seeing
+        this error because you have <code>DEBUG = True</code> in\n      your Django
+        settings file. Change that to <code>False</code>, and Django\n      will display
+        a standard 404 page.\n    </p>\n  </div>\n</body>\n</html>\n"}
+    headers:
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [text/html]
+      Date: ['Mon, 07 May 2018 07:27:16 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
+    status: {code: 404, message: NOT FOUND}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.1]
+    method: DELETE
+    uri: http://192.168.168.192/api/ingest/b72afa68-9e82-410d-9235-02fa10512e14/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
+  response:
+    body: {string: '{"removed": true}'}
+    headers:
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 May 2018 07:27:16 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.1]
+    method: DELETE
+    uri: http://192.168.168.192/api/ingest/777a9d9e-baad-f00d-8c7e-00b75773672d/delete/?username=test&api_key=3c23b0361887ace72b9d42963d9acbdf06644673
+  response:
+    body: {string: "\n<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta http-equiv=\"content-type\"
+        content=\"text/html; charset=utf-8\">\n  <title>Page not found at /api/ingest/777a9d9e-baad-f00d-8c7e-00b75773672d/delete/</title>\n
+        \ <meta name=\"robots\" content=\"NONE,NOARCHIVE\">\n  <style type=\"text/css\">\n
+        \   html * { padding:0; margin:0; }\n    body * { padding:10px 20px; }\n    body
+        * * { padding:0; }\n    body { font:small sans-serif; background:#eee; }\n
+        \   body>div { border-bottom:1px solid #ddd; }\n    h1 { font-weight:normal;
+        margin-bottom:.4em; }\n    h1 span { font-size:60%; color:#666; font-weight:normal;
+        }\n    table { border:none; border-collapse: collapse; width:100%; }\n    td,
+        th { vertical-align:top; padding:2px 3px; }\n    th { width:12em; text-align:right;
+        color:#666; padding-right:.5em; }\n    #info { background:#f6f6f6; }\n    #info
+        ol { margin: 0.5em 4em; }\n    #info ol li { font-family: monospace; }\n    #summary
+        { background: #ffc; }\n    #explanation { background:#eee; border-bottom:
+        0px none; }\n  </style>\n</head>\n<body>\n  <div id=\"summary\">\n    <h1>Page
+        not found <span>(404)</span></h1>\n    <table class=\"meta\">\n      <tr>\n
+        \       <th>Request Method:</th>\n        <td>DELETE</td>\n      </tr>\n      <tr>\n
+        \       <th>Request URL:</th>\n        <td>http://192.168.168.192/api/ingest/777a9d9e-baad-f00d-8c7e-00b75773672d/delete/?username=test&amp;api_key=3c23b0361887ace72b9d42963d9acbdf06644673</td>\n
+        \     </tr>\n      \n      <tr>\n        <th>Raised by:</th>\n        <td>components.api.views.wrapper</td>\n
+        \     </tr>\n      \n    </table>\n  </div>\n  <div id=\"info\">\n    \n      <p></p>\n
+        \   \n  </div>\n\n  <div id=\"explanation\">\n    <p>\n      You're seeing
+        this error because you have <code>DEBUG = True</code> in\n      your Django
+        settings file. Change that to <code>False</code>, and Django\n      will display
+        a standard 404 page.\n    </p>\n  </div>\n</body>\n</html>\n"}
+    headers:
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [text/html]
+      Date: ['Mon, 07 May 2018 07:27:16 GMT']
+      Server: [nginx/1.12.2]
+      Vary: ['Accept-Language, Cookie']
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fixtures/vcr_cassettes/test_transfer_approve_transfer.yaml
+++ b/fixtures/vcr_cassettes/test_transfer_approve_transfer.yaml
@@ -1,0 +1,149 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://127.0.0.1/api/transfer/unapproved?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"message": "Fetched unapproved transfers successfully.",
+        "results": [{"directory": "unzipped_bag_1", "type": "unzipped bag", "uuid": "8779909c-20e8-4471-beb2-c45591b7abb0"},
+        {"directory": "dspace_1", "type": "dspace", "uuid": "f25c71e6-1f1e-4e69-bf57-580a64d4e051"},
+        {"directory": "standard_1", "type": "standard", "uuid": "0d16e57f-df1b-4a66-a93c-989f0dc9f16f"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Mon, 30 Apr 2018 14:07:23 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode username=demo&directory=unzipped_bag_1&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&type=unzipped+bag
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['69']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://127.0.0.1/api/transfer/approve/
+  response:
+    body: {string: !!python/unicode '{"message": "Approval successful.", "uuid": "8779909c-20e8-4471-beb2-c45591b7abb0"}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Mon, 30 Apr 2018 14:07:24 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://127.0.0.1/api/transfer/unapproved?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"message": "Fetched unapproved transfers successfully.",
+        "results": [{"directory": "dspace_1", "type": "dspace", "uuid": "f25c71e6-1f1e-4e69-bf57-580a64d4e051"},
+        {"directory": "standard_1", "type": "standard", "uuid": "0d16e57f-df1b-4a66-a93c-989f0dc9f16f"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Mon, 30 Apr 2018 14:07:30 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode username=demo&directory=dspace_1&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&type=dspace
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['57']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://127.0.0.1/api/transfer/approve/
+  response:
+    body: {string: !!python/unicode '{"message": "Approval successful.", "uuid": "f25c71e6-1f1e-4e69-bf57-580a64d4e051"}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Mon, 30 Apr 2018 14:07:31 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://127.0.0.1/api/transfer/unapproved?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"message": "Fetched unapproved transfers successfully.",
+        "results": [{"directory": "standard_1", "type": "standard", "uuid": "0d16e57f-df1b-4a66-a93c-989f0dc9f16f"},
+        {"directory": "2", "type": "dspace", "uuid": "47908337-3134-4871-8f41-a9d7d500c2e0"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Mon, 30 Apr 2018 14:07:37 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode username=demo&directory=standard_1&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef&type=standard
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['61']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://127.0.0.1/api/transfer/approve/
+  response:
+    body: {string: !!python/unicode '{"message": "Approval successful.", "uuid": "0d16e57f-df1b-4a66-a93c-989f0dc9f16f"}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Mon, 30 Apr 2018 14:07:38 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://127.0.0.1/api/transfer/unapproved?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"message": "Fetched unapproved transfers successfully.",
+        "results": [{"directory": "transfer_1", "type": "dspace", "uuid": "47908337-3134-4871-8f41-a9d7d500c2e0"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Mon, 30 Apr 2018 14:07:44 GMT']
+      server: [nginx/1.12.2]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/transfer_status.yaml
+++ b/fixtures/vcr_cassettes/transfer_status.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192/api/transfer/status/63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9/
+  response:
+    body: {string: !!python/unicode '{"status": "COMPLETE", 
+        "name": "transfer_test_1", "sip_uuid": "BACKLOG", "microservice": 
+        "Create placement in backlog PREMIS events", "directory": 
+        "transfer_test_1-63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9", 
+        "path": "/var/archivematica/sharedDirectory/watchedDirectories/SIPCreation/completedTransfers/transfer_test_1-63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9/", 
+        "message": "Fetched status for 63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9 successfully.", 
+        "type": "transfer", "uuid": "63fcc1b0-f83d-47e6-ac9d-a8f8d1fc2ab9"}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/transfer_status_invalid_uuid.yaml
+++ b/fixtures/vcr_cassettes/transfer_status_invalid_uuid.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.6 Linux/3.13.0-87-generic]
+      Authorization: ['ApiKey test:test']
+    method: GET
+    uri: http://192.168.168.192/api/transfer/status/7bffc8f7-baad-f00d-8120-b1c51c2ab5db/
+  response:
+    body: {string: !!python/unicode '{"message": 
+        "Cannot fetch unitTransfer with UUID 7bffc8f7-baad-f00d-8120-b1c51c2ab5db", 
+        "type": "transfer", "error": true}'}
+    headers:
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Sat, 07 Apr 2018 16:59:25 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.7 (Ubuntu)]
+      vary: [Cookie]
+    status: {code: 200, message: OK}
+version: 1

--- a/transfers/amclientargs.py
+++ b/transfers/amclientargs.py
@@ -24,13 +24,21 @@ AIP_UUID = Arg(
     name='aip_uuid',
     help='UUID of the target AIP',
     type=None)
-AM_API_KEY = Arg(
-    name='am_api_key',
-    help='Archivematica API key',
-    type=None)
 DIP_UUID = Arg(
     name='dip_uuid',
     help='UUID of the target DIP',
+    type=None)
+SIP_UUID = Arg(
+    name='sip_uuid',
+    help='UUID of the target SIP',
+    type=None)
+TRANSFER_UUID = Arg(
+    name='transfer_uuid',
+    help='UUID of the target Transfer',
+    type=None)
+AM_API_KEY = Arg(
+    name='am_api_key',
+    help='Archivematica API key',
     type=None)
 SS_API_KEY = Arg(
     name='ss_api_key',
@@ -39,6 +47,18 @@ SS_API_KEY = Arg(
 TRANSFER_SOURCE = Arg(
     name='transfer_source',
     help='Transfer source UUID',
+    type=None)
+PACKAGE_UUID = Arg(
+    name="package_uuid",
+    help="UUID of the package in the storage service",
+    type=None)
+PIPELINE_UUID = Arg(
+    name="pipeline_uuid",
+    help="UUID of the pipeline to use",
+    type=None)
+TRANSFER_DIRECTORY = Arg(
+    name="transfer_directory",
+    help="Directory of a potential Archivematica transfer",
     type=None)
 
 # Reusable option constants (for CLI).
@@ -86,7 +106,27 @@ TRANSFER_PATH = Opt(
     help='Relative path within the Transfer Source. Default: ""',
     default=b'',
     type=fsencode)
-
+PROCESSING_CONFIG = Opt(
+    name='processing-config',
+    metavar='PROCESSING',
+    help='Processing configuration. Default: {0}'.format(
+        defaults.DEFAULT_PROCESSING_CONFIG),
+    default=defaults.DEFAULT_PROCESSING_CONFIG,
+    type=None)
+REINGEST_TYPE = Opt(
+    name='reingest-type',
+    metavar='REINGEST',
+    help='Reingest type. Default: {0}'.format(
+        defaults.DEFAULT_REINGEST_TYPE),
+    default=defaults.DEFAULT_REINGEST_TYPE,
+    type=None)
+TRANSFER_TYPE = Opt(
+    name='transfer-type',
+    metavar='TRANSFER',
+    help='Reingest type. Default: {0}'.format(
+        defaults.DEFAULT_TRANSFER_TYPE),
+    default=defaults.DEFAULT_TRANSFER_TYPE,
+    type=None)
 
 # Sub-command configuration: give them a name, help text, a tuple of ``Arg``
 # instances and a tuple of ``Opts`` instances.
@@ -141,6 +181,12 @@ SUBCOMMANDS = (
         opts=(SS_USER_NAME, SS_URL, OUTPUT_MODE)
     ),
     SubCommand(
+        name='get-all-compressed-aips',
+        help='Print all compressed AIPs in the Storage Service.',
+        args=(SS_API_KEY,),
+        opts=(SS_USER_NAME, SS_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
         name='aips2dips',
         help='Print all AIPs in the Storage Service along with their '
              'corresponding DIPs.',
@@ -159,6 +205,48 @@ SUBCOMMANDS = (
         help='Download the DIP with DIP_UUID.',
         args=(DIP_UUID, SS_API_KEY),
         opts=(SS_USER_NAME, SS_URL, DIRECTORY, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='get-pipelines',
+        help='List (enabled) Pipelines known to the Storage Service.',
+        args=(SS_API_KEY,),
+        opts=(SS_USER_NAME, SS_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='get-transfer-status',
+        help='Print the status of a transfer if it exists in a transfer workflow.',
+        args=(TRANSFER_UUID, AM_API_KEY),
+        opts=(AM_USER_NAME, AM_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='get-ingest-status',
+        help='Print the status of an ingest if it exists in an ingest workflow.',
+        args=(SIP_UUID, AM_API_KEY),
+        opts=(AM_USER_NAME, AM_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='get-processing-config',
+        help='Print a processing configuration file given its name in Archivematica.',
+        args=(AM_API_KEY,),
+        opts=(PROCESSING_CONFIG, AM_USER_NAME, AM_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='approve-transfer',
+        help='Approve a transfer in the Archivematica pipeline with a given UUID.',
+        args=(TRANSFER_DIRECTORY, AM_API_KEY),
+        opts=(TRANSFER_TYPE, AM_USER_NAME, AM_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='reingest-aip',
+        help='Initiate the reingest of an AIP from the storage service with a given UUID.',
+        args=(PIPELINE_UUID, AIP_UUID, SS_API_KEY),
+        opts=(REINGEST_TYPE, PROCESSING_CONFIG, SS_USER_NAME, SS_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='get-package-details',
+        help='Retrieve details about a package in the storage service with a given UUID.',
+        args=(PACKAGE_UUID, SS_API_KEY),
+        opts=(SS_USER_NAME, SS_URL, OUTPUT_MODE)
     )
 )
 

--- a/transfers/defaults.py
+++ b/transfers/defaults.py
@@ -25,3 +25,12 @@ TRANSFER_LOG_FILE = os.path.join(THIS_DIR, 'automate-transfer.log')
 
 # Default log level.
 DEFAULT_LOG_LEVEL = "INFO"
+
+# Default Processing Configuration
+DEFAULT_PROCESSING_CONFIG = "default"
+
+# Default reingest type
+DEFAULT_REINGEST_TYPE = "full"
+
+# Default transfer type
+DEFAULT_TRANSFER_TYPE = "standard"

--- a/transfers/errors.py
+++ b/transfers/errors.py
@@ -3,13 +3,16 @@
 ERR_INVALID_RESPONSE = 1
 ERR_PARSE_JSON = 2
 ERR_SERVER_CONN = 3
+ERR_INVALID_URL = 4
 ERR_CLIENT_UNKNOWN = -1
 
 error_codes = {
     ERR_INVALID_RESPONSE: "Invalid response from server, check amclient log",
     ERR_PARSE_JSON: "Could not parse JSON resposne, check amclient log",
     ERR_SERVER_CONN: "Error connecting to the server, check amclient log",
-    ERR_CLIENT_UNKNOWN: "Unknown return from amclient, check logs."}
+    ERR_CLIENT_UNKNOWN: "Unknown return from amclient, check logs",
+    ERR_INVALID_URL: "Invalid URL passed to AM Client"
+}
 
 
 def error_lookup(errcode):

--- a/transfers/models.py
+++ b/transfers/models.py
@@ -20,8 +20,9 @@ class Unit(Base):
     current = Column(Boolean(create_constraint=False))
 
     def __repr__(self):
-        return "<Unit(id={s.id}, uuid={s.uuid}, unit_type={s.unit_type}, \
-        path={s.path}, status={s.status}, current={s.current})>".format(s=self)
+        return ("<Unit(id={s.id}, uuid={s.uuid}, unit_type={s.unit_type}, "
+                "path={s.path}, status={s.status}, current={s.current})>"
+                .format(s=self))
 
 
 def init(databasefile):

--- a/transfers/utils.py
+++ b/transfers/utils.py
@@ -11,43 +11,61 @@ from six import binary_type, text_type
 
 from transfers import errors
 
+
 LOGGER = logging.getLogger('transfers')
 
+METHOD_GET = "GET"
+METHOD_POST = "POST"
+METHOD_DELETE = "DELETE"
 
-def _call_url_json(url, params, method='GET'):
+
+def _call_url_json(url, params=None, method=METHOD_GET, headers=None,
+                   assume_json=True):
     """Helper to GET a URL where the expected response is 200 with JSON.
 
     :param str url: URL to call
-    :param dict params: Params to pass to requests.get
+    :param dict params: Params to pass as HTTP query string or JSON body
+    :param str method: HTTP method (e.g., 'GET')
+    :param dict headers: HTTP headers
+    :param bool assume_json: set to False if the response body should not be
+                             decoded as JSON
     :returns: Dict of the returned JSON or an integer error
-              code to be looked up
+            code to be looked up
     """
     method = method.upper()
     LOGGER.debug('URL: %s; params: %s; method: %s', url, params, method)
-
     try:
-        response = requests.request(method, url=url, params=params)
+        if method == METHOD_GET or method == METHOD_DELETE:
+            response = requests.request(method,
+                                        url=url,
+                                        params=params,
+                                        headers=headers)
+        else:
+            response = requests.request(method,
+                                        url=url,
+                                        data=params,
+                                        headers=headers)
         LOGGER.debug('Response: %s', response)
         LOGGER.debug('type(response.text): %s ', type(response.text))
         LOGGER.debug('Response content-type: %s',
                      response.headers['content-type'])
-
-        if not response.ok:
-            LOGGER.warning('%s Request to %s returned %s %s', method, url,
-                           response.status_code, response.reason)
-            LOGGER.debug('Response: %s', response.text)
-            return errors.ERR_INVALID_RESPONSE
+    except (urllib3.exceptions.NewConnectionError,
+            requests.exceptions.ConnectionError) as err:
+        LOGGER.error("Connection error %s", err)
+        return errors.ERR_SERVER_CONN
+    if not response.ok:
+        LOGGER.warning('%s Request to %s returned %s %s', method, url,
+                       response.status_code, response.reason)
+        LOGGER.debug('Response: %s', response.text)
+        return errors.ERR_INVALID_RESPONSE
+    if assume_json:
         try:
             return response.json()
         except ValueError:  # JSON could not be decoded
             LOGGER.warning('Could not parse JSON from response: %s',
                            response.text)
             return errors.ERR_PARSE_JSON
-
-    except (urllib3.exceptions.NewConnectionError,
-            requests.exceptions.ConnectionError) as err:
-        LOGGER.error("Connection error %s", err)
-        return errors.ERR_SERVER_CONN
+    return response.text
 
 
 try:


### PR DESCRIPTION
This PR adds capability to AM Client in support of the API functions
required for automated reingest.

* Adds new functions to AM Client, including reingest and transfer status.
* Provides unit testing for the additional function calls.
* Extends utils.py request mechanism to enable http authentication headers
  to be set.
* A formatting issue was discovered in models.py while testing which
  is now corrected.
* Warning for non-JSON responses are only output if there is a non-OK
  HTTP response where responses from the API are not always JSON.


Submitted as part of Redmine ticket 11686 for CCA in support of automated reingest, cc. @timothyryanwalsh.