### PR TITLE
Add delete-on-complete option to automation tools master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The `transfers.py` script can be modified to adjust how automated transfers work
 * `--transfer-type TYPE`: Type of transfer to start. One of: 'standard' (default), 'unzipped bag', 'zipped bag', 'dspace'.
 * `--files`: If set, start transfers from files as well as folders.
 * `--hide`: If set, hides the Transfer and SIP once completed.
+* `--delete`: If set, delete transfer source files from watched directory once completed.
 * `-c FILE, --config-file FILE`: config file containing file paths for log/database/PID files. Default: log/database/PID files stored in the same directory as the script (not recommended for production)
 * `-v, --verbose`: Increase the debugging output. Can be specified multiple times, e.g. `-vv`
 * `-q, --quiet`: Decrease the debugging output. Can be specified multiple times, e.g. `-qq`

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -33,8 +33,8 @@ class TestAutomateTransfers(unittest.TestCase):
     def test_get_status_transfer(self):
         transfer_uuid = 'dfc8cf5f-b5b1-408c-88b1-34215964e9d6'
         transfer_name = 'test1'
-        info = transfer.get_status(AM_URL, USER, API_KEY, transfer_uuid,
-                                   'transfer', session)
+        info = transfer.get_status(AM_URL, USER, API_KEY, SS_URL, SS_USER,
+                                   SS_KEY, transfer_uuid, 'transfer', session)
         assert isinstance(info, dict)
         assert info['status'] == 'USER_INPUT'
         assert info['type'] == 'transfer'
@@ -62,8 +62,8 @@ class TestAutomateTransfers(unittest.TestCase):
         session.commit()
 
         # Run test
-        info = transfer.get_status(AM_URL, USER, API_KEY, transfer_uuid,
-                                   'transfer', session)
+        info = transfer.get_status(AM_URL, USER, API_KEY, SS_URL, SS_USER,
+                                   SS_KEY, transfer_uuid, 'transfer', session)
         # Verify
         assert isinstance(info, dict)
         assert info['status'] == 'USER_INPUT'
@@ -80,8 +80,8 @@ class TestAutomateTransfers(unittest.TestCase):
     def test_get_status_ingest(self):
         sip_uuid = 'f2248e2a-b593-43db-b60c-fa8513021785'
         sip_name = 'test1'
-        info = transfer.get_status(AM_URL, USER, API_KEY, sip_uuid,
-                                   'ingest', session)
+        info = transfer.get_status(AM_URL, USER, API_KEY, SS_URL, SS_USER,
+                                   SS_KEY, sip_uuid, 'ingest', session)
         assert isinstance(info, dict)
         assert info['status'] == 'USER_INPUT'
         assert info['type'] == 'SIP'
@@ -96,16 +96,16 @@ class TestAutomateTransfers(unittest.TestCase):
     @vcr.use_cassette('fixtures/vcr_cassettes/get_status_no_unit.yaml')
     def test_get_status_no_unit(self):
         transfer_uuid = 'deadc0de-c0de-c0de-c0de-deadc0dec0de'
-        info = transfer.get_status(AM_URL, USER, API_KEY, transfer_uuid,
-                                   'transfer', session)
+        info = transfer.get_status(AM_URL, USER, API_KEY, SS_URL, SS_USER,
+                                   SS_KEY, transfer_uuid, 'transfer', session)
         self.assertEqual(info,
                          errors.error_lookup(errors.ERR_INVALID_RESPONSE))
 
     @vcr.use_cassette('fixtures/vcr_cassettes/get_status_not_json.yaml')
     def test_get_status_not_json(self):
         transfer_uuid = 'dfc8cf5f-b5b1-408c-88b1-34215964e9d6'
-        info = transfer.get_status(AM_URL, USER, API_KEY, transfer_uuid,
-                                   'transfer', session)
+        info = transfer.get_status(AM_URL, USER, API_KEY, SS_URL, SS_USER,
+                                   SS_KEY, transfer_uuid, 'transfer', session)
         self.assertEqual(info,
                          errors.error_lookup(errors.ERR_INVALID_RESPONSE))
 

--- a/transfers/transferargs.py
+++ b/transfers/transferargs.py
@@ -60,6 +60,9 @@ def get_parser(doc):
     parser.add_argument('--hide', action='store_true',
                         help='If set, hide the Transfers and SIPs in the '
                              'dashboard once they complete.')
+    parser.add_argument('--delete-on-complete', action='store_true',
+                        help='If set, delete transfer source files after '
+                             'ingest successfully completes.')
     parser.add_argument('-c', '--config-file', metavar='FILE',
                         help='Configuration file(log/db/PID files)',
                         default=None)


### PR DESCRIPTION
From PR #44, we have brought that PR into the Artefactual hosted repository, squashed the previous commits, and made some final modifications via commit 442c49f. 

@timothyryanwalsh are you happy with the final changes here? 442c49f 

* Added a note to the deletion log that a failure  might be because of the script being run remotely
* Corrected an argument being passed to `AMClient()`
* Added some minor string formatting changes to the `get_status()` function while there was an opportunity to look at the code
* Made the `--delete` flag more verbose, now `--delete-on-complete`
* Used `.get()` for dictionary look-ups to avoid potential `KeyError`

Let me know! 

Once squished again we'll close PR #44 and #75 via here.