### PR TITLE
Various fixes to improve automation-tools debugging, and create more seamless execution

### DIFF
--- a/fixtures/vcr_cassettes/test_call_start_transfer_endpoint.yaml
+++ b/fixtures/vcr_cassettes/test_call_start_transfer_endpoint.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: !!python/unicode 'type=standard&row_ids%5B%5D=&paths%5B%5D=MmEzZDhkMzktOWNlZS00OTVlLWI3ZWUtNWU2MjkyNTQ5MzRkOnN0YW5kYXJkXzE%3D&name=standard_1&accession=standard_1'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['144']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: http://127.0.0.1/api/transfer/start_transfer/?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"path": "/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer/standard_1/",
+        "message": "Copy successful."}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Tue, 18 Dec 2018 09:28:04 GMT']
+      server: [nginx/1.14.1]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'type=standard&row_ids%5B%5D=&paths%5B%5D=MmEzZDhkMzktOWNlZS00OTVlLWI3ZWUtNWU2MjkyNTQ5MzRkOnN0YW5kYXJkXzE%3D&name=standard_1&accession=standard_1'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['144']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: http://127.0.0.1/api/transfer/start_transfer/?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"path": "/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer/standard_1_1/",
+        "message": "Copy successful."}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Tue, 18 Dec 2018 09:28:15 GMT']
+      server: [nginx/1.14.1]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'type=dspace&row_ids%5B%5D=&paths%5B%5D=MmEzZDhkMzktOWNlZS00OTVlLWI3ZWUtNWU2MjkyNTQ5MzRkOmRzcGFjZV8xLnppcA%3D%3D&name=dspace_1.zip&accession=dspace_1.zip'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['152']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: http://127.0.0.1/api/transfer/start_transfer/?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"path": "/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/Dspace/dspace_1.zip",
+        "message": "Copy successful."}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Tue, 18 Dec 2018 09:28:25 GMT']
+      server: [nginx/1.14.1]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'type=dspace&row_ids%5B%5D=&paths%5B%5D=MmEzZDhkMzktOWNlZS00OTVlLWI3ZWUtNWU2MjkyNTQ5MzRkOmRzcGFjZV8xLnppcA%3D%3D&name=dspace_1.zip&accession=dspace_1.zip'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['152']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: http://127.0.0.1/api/transfer/start_transfer/?username=demo&api_key=1c34274c0df0bca7edf9831dd838b4a6345ac2ef
+  response:
+    body: {string: !!python/unicode '{"path": "/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/Dspace/dspace_1_1.zip",
+        "message": "Copy successful."}'}
+    headers:
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Tue, 18 Dec 2018 09:28:36 GMT']
+      server: [nginx/1.14.1]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Language, Cookie']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_transfer_model.py
+++ b/tests/test_transfer_model.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.orm.session import Session
+
+from transfers import models
+
+
+@pytest.fixture
+def setup_session():
+    """Cleanup any previous transaction and initialize a new database and
+    session to work with."""
+    if models.Session:
+        models.cleanup_session()
+        models.Session = None
+    models.init_session(":memory:")
+    try:
+        models.transfer_session.query(models.Unit).one()
+    except MultipleResultsFound:
+        assert False
+    except NoResultFound:
+        assert True
+
+
+def test_database_init():
+    """Test the initialization of the database. Ensure that we return a
+    Session object. It would be very easy to return a scoped_session object
+    and otherwise start using that."""
+    assert models.transfer_session is None
+    models.init_session(":memory:")
+    assert isinstance(models.transfer_session, Session)
+
+
+def test_get_functions(setup_session):
+    """Test the various get functions of the models module."""
+    transfer_one_uuid = str(uuid4())
+    models._update_unit(
+        uuid=transfer_one_uuid, path=b'/foo', unit_type="transfer",
+        status="PROCESSING", current=True)
+    unit = models.get_current_unit()
+    assert unit.uuid == transfer_one_uuid
+    transfer_two_uuid = str(uuid4())
+    models._update_unit(
+        uuid=transfer_two_uuid, path=b'/bar', unit_type="ingest",
+        status="COMPLETE", current=False)
+    unit_two = models.retrieve_unit_by_type_and_uuid(
+        unit_type='ingest', uuid=transfer_two_uuid)
+    unit_one = models.retrieve_unit_by_type_and_uuid(
+        unit_type='transfer', uuid=transfer_one_uuid)
+    assert unit_one.uuid == transfer_one_uuid
+    assert unit_two.uuid == transfer_two_uuid
+    all_processed_paths = models.get_processed_transfer_paths()
+    assert len(all_processed_paths) is 2
+
+
+def test_start_Transfer_unit_state(setup_session):
+    """Test functions associated with setting unit state at the beginning of a
+    new automated transfer.
+    """
+    transfer_uuid_one = str(uuid4())
+    models.add_new_transfer(uuid=transfer_uuid_one, path=b"/foo")
+    unit = models.transfer_session.query(models.Unit).\
+        filter_by(path=b"/foo").one()
+    models.transfer_failed_to_start(path=b"/bar")
+    unit = models.transfer_session.query(models.Unit).\
+        filter_by(path=b"/bar").one()
+    models.failed_to_approve(b"/foobar")
+    assert unit.current is False
+    assert unit.uuid == ""
+    assert unit.status == "FAILED"
+    unit = models.transfer_session.query(models.Unit).\
+        filter_by(path=b"/foobar").one()
+    assert unit.current is False
+    assert unit.uuid is None
+
+
+def test_update_unit_attributes(setup_session):
+    """Test functions associated with updating object attributes in the
+    database.
+    """
+    transfer_one_uuid = str(uuid4())
+    ingest_one_uuid = str(uuid4())
+    models._update_unit(
+        uuid=transfer_one_uuid, path=b'/foo', unit_type="transfer",
+        status="PROCESSING", current=True)
+    unit = models.transfer_session.query(models.Unit).one()
+    assert unit.uuid == transfer_one_uuid
+    assert unit.unit_type == "transfer"
+    assert unit.microservice == ""
+    assert unit.current is True
+    assert unit.status == "PROCESSING"
+    models.update_unit_type_and_uuid(
+        unit=unit, unit_type="ingest", uuid=ingest_one_uuid)
+    models.update_unit_microservice(
+        unit=unit, microservice="Generate METS.xml document")
+    models.update_unit_current(unit=unit, current=False)
+    models.update_unit_status(unit=unit, status="COMPLETE")
+    unit = models.transfer_session.query(models.Unit).one()
+    assert unit.uuid == ingest_one_uuid
+    assert unit.unit_type == "ingest"
+    assert unit.microservice == "Generate METS.xml document"
+    assert unit.current is False
+    assert unit.status == "COMPLETE"

--- a/transfers/models.py
+++ b/transfers/models.py
@@ -1,19 +1,23 @@
-from os.path import isfile
-
+# -*- coding: utf-8 -*-
 from sqlalchemy import create_engine
 from sqlalchemy import Sequence
-from sqlalchemy import Column, Binary, Boolean, Integer, String
+from sqlalchemy import Column, LargeBinary, Boolean, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, scoped_session
 
 Base = declarative_base()
+Session = None
+transfer_session = None
 
 
 class Unit(Base):
+    """Object that represents transfer units in the automation tools database.
+    """
     __tablename__ = 'unit'
+
     id = Column(Integer, Sequence('user_id_seq'), primary_key=True)
     uuid = Column(String(36))
-    path = Column(Binary())
+    path = Column(LargeBinary())
     unit_type = Column(String(10))  # ingest or transfer
     status = Column(String(20), nullable=True)
     microservice = Column(String(50))
@@ -25,12 +29,105 @@ class Unit(Base):
                 .format(s=self))
 
 
-def init(databasefile):
-    if not isfile(databasefile):
-        # We create the file
-        with open(databasefile, "a"):
-            pass
+def init_session(databasefile):
+    """Initialize the database given a database filename and initiate the
+    database session to use throughout our transactions.
+    """
     engine = create_engine('sqlite:///{}'.format(databasefile), echo=False)
     global Session
-    Session = sessionmaker(bind=engine)
+    Session = scoped_session(sessionmaker())
+    Session.configure(bind=engine)
+    global transfer_session
+    transfer_session = Session()
     Base.metadata.create_all(engine)
+
+
+def cleanup_session():
+    """Call remove to clean up the current session's transactions."""
+    Session.remove()
+
+
+def get_current_unit():
+    """Query the database for current units. Return the first."""
+    return transfer_session.query(Unit).filter_by(current=True).one()
+
+
+def get_processed_transfer_paths():
+    """Return a set that represents the processed transfer paths in the
+    database. Set is a set of all paths in the database. The caller needs to
+    create a delta by comparing the result to other data points, e.g. a list of
+    paths of its own.
+    """
+    return {x[0] for x in transfer_session.query(Unit.path).all()}
+
+
+def retrieve_unit_by_type_and_uuid(uuid, unit_type):
+    """Given a unit_type and uuid for that unit, return the unit object that
+    represents it.
+    """
+    return transfer_session.query(Unit).\
+        filter_by(unit_type=unit_type, uuid=uuid).one()
+
+
+def _update_unit(uuid, path, unit_type, status, current, microservice=""):
+    """Internal function to handle the updating of a unit in the database as
+    a single atomic transaction.
+    """
+    unit = Unit(
+        uuid=uuid, path=path, unit_type=unit_type, status=status,
+        current=current, microservice=microservice)
+    transfer_session.add(unit)
+    transfer_session.commit()
+    return unit
+
+
+def add_new_transfer(uuid, path):
+    """Add a new transfer unit to the database."""
+    return _update_unit(
+        uuid=uuid, path=path, unit_type="transfer", status="",
+        current=True)
+
+
+def transfer_failed_to_start(path):
+    """Update a unit when its transfer has failed to start."""
+    _update_unit(
+        uuid="", path=path, unit_type="transfer", status="FAILED",
+        current=False)
+
+
+def failed_to_approve(path):
+    """Update a unit when it has failed to be approved by the automation
+    tools.
+    """
+    return _update_unit(
+        uuid=None, path=path, unit_type="transfer", status="",
+        current=False)
+
+
+def update_unit_type_and_uuid(unit, unit_type, uuid):
+    """Update the unit_type and uuid for a unit, e.g. when a transfer unit
+    becomes a SIP within the ingest workflow.
+    """
+    unit.unit_type = unit_type
+    unit.uuid = uuid
+    transfer_session.commit()
+
+
+def update_unit_microservice(unit, microservice):
+    """Update the microservice column of the given unit."""
+    unit.microservice = microservice
+    transfer_session.commit()
+
+
+def update_unit_current(unit, current):
+    """Update the 'current' parameter of the given unit, e.g. when the unit
+    is still current and needs to be processed by the automation tools.
+    """
+    unit.current = current
+    transfer_session.commit()
+
+
+def update_unit_status(unit, status):
+    """Update the status of the given unit, e.g. COMPLETED, PROCESSING, etc."""
+    unit.status = status
+    transfer_session.commit()


### PR DESCRIPTION
This PR is in support of the work being done to debug the automation-tools workflow at the University of Melbourne where a number of issues have been observed, but cannot all be pinned down accurately without automation-tools performing better. 

* We now supply the config_file argument consistently to all run_scripts functions.
* Exception handling has been made more specific to ensure tha other errors are not masked during execution.
* A post-execution hook has been implemented to clean-up the script once it has successfully exited, e.g. to ensure that the process lock pid.lck file is removed without having to explicitly make that call more than once in the code.
* The post-execution hook will also look after the session closure for the database.
* Logging has been improved where possible to either shorten output not being directed to a DEBUG log, or make messages clearer or more specific when sent elsewhere.
* Transfers with duplicate names which are renamed in Archivematica can now be handled by the Automation Tools. 
* A unit test has been written to test this function against the API. 
* Database functions have been moved to the `models.py` module to separate the concerns of the code and to provide greater visibility of the work being done to talk to the database. This change should open up the opportunity to make the data stored in the database more expressive. 
* An SQLAlchemy data type renamed in the SQLAlchemy library has been renamed according to the tox warnings.

Connected to archivematica/issues#362
Connected to archivematica/issues#365
Connected to archivematica/issues#366
Connected to archivematica/issues#372
Connected to archivematica/issues#381
Connected to archivematica/issues#395
Connected to https://github.com/artefactual/automation-tools/issues/5

There are three parts to this which affect https://github.com/artefactual/automation-tools/issues/5, 1. the behavior couldn't be recreated; 2. there should be less risk with greater number of atomic commits that there will be any negative impact of a database connection being left open too long; 3. The session is now closed by the automation tools where previously this wasn't an explicit call made in the code. 