### PR TITLE
Fixes regression involving target name and introduces a new integration test

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,3 +3,4 @@ pytest
 vcrpy>=1.0.0
 flake8==3.4.1
 flake8-import-order==0.13
+mock

--- a/transfers/transfer.py
+++ b/transfers/transfer.py
@@ -411,8 +411,9 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path,
         transfer_type=transfer_type, accession=accession,
         ts_location_uuid=ts_location_uuid)
     if not transfer_name:
-        LOGGER.info("Cannot begin transfer with target_name: %s", transfer_name)
-        models.transfer_failed_to_start(transfer_abs_path)
+        LOGGER.info(
+            "Cannot begin transfer with target name: %s", target)
+        models.transfer_failed_to_start(target)
         return None
     # Run all pre-transfer scripts on the unapproved transfer directory.
     LOGGER.info("Attempting to run pre-transfer scripts on: %s", transfer_name)
@@ -436,14 +437,14 @@ def start_transfer(ss_url, ss_user, ss_api_key, ts_location_uuid, ts_path,
             # Store the absolute path to help users to determine what type
             # the transfer is, and where something it is.
             new_transfer = models.add_new_transfer(
-                uuid=result, path=transfer_abs_path)
+                uuid=result, path=target)
             LOGGER.info('New transfer: %s', new_transfer)
             break
         LOGGER.info(
             'Failed transfer approval, try %s of %s', i + 1, retry_count)
     else:
         new_transfer = models.failed_to_approve(
-            path=transfer_abs_path)
+            path=target)
         LOGGER.warning('Transfer not approved: %s', transfer_name)
         return None
     # Start transfer completed successfully.


### PR DESCRIPTION
This PR is separated into two commits which will be squished before merging. One to demonstrate the issue reported in the original ticket. The tests will fail. We test for the values we want, not the values we're writing. 

The second commit then introduces the correct values to `transfer.py` so that the tests pass. 

archivematica/Issues#447

**NB** The reason for the additional caution i.e. the two commits is due to the regressions introduced during the previous two commits. This PR is simply a corrective one. In future, if we can refactor this function we should  be able to make the automation tools even more robust. 