### PR TITLE
Add functions required for AMAUAT black-box tests

### DIFF
--- a/fixtures/vcr_cassettes/get_default_locations.yaml
+++ b/fixtures/vcr_cassettes/get_default_locations.yaml
@@ -1,0 +1,64 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [!!python/unicode 'ApiKey test:5de62f6f4817f903dcfac47fa5cffd44685a2cf2']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/location/?%7B%7D
+  response:
+    body: {string: !!python/unicode '{"meta": {"limit": 20, "next": null, "offset":
+        0, "previous": null, "total_count": 7}, "objects": [{"description": "", "enabled":
+        true, "path": "/home", "pipeline": ["/api/v2/pipeline/1ffc9650-4862-4e53-a4f1-9c7e2a26ab72/"],
+        "purpose": "TS", "quota": null, "relative_path": "home", "resource_uri": "/api/v2/location/d1184f7f-d755-4c8d-831a-a3793b88f760/",
+        "space": "/api/v2/space/f18ad8dd-9082-4f5c-bc67-b976e370fa90/", "used": "0",
+        "uuid": "d1184f7f-d755-4c8d-831a-a3793b88f760"}, {"description": "Store AIP
+        in standard Archivematica Directory", "enabled": true, "path": "/var/archivematica/sharedDirectory/www/AIPsStore",
+        "pipeline": ["/api/v2/pipeline/1ffc9650-4862-4e53-a4f1-9c7e2a26ab72/"], "purpose":
+        "AS", "quota": null, "relative_path": "var/archivematica/sharedDirectory/www/AIPsStore",
+        "resource_uri": "/api/v2/location/471ff191-2c03-441d-b1d6-0c39d27a6b66/",
+        "space": "/api/v2/space/f18ad8dd-9082-4f5c-bc67-b976e370fa90/", "used": "0",
+        "uuid": "471ff191-2c03-441d-b1d6-0c39d27a6b66"}, {"description": "Store DIP
+        in standard Archivematica Directory", "enabled": true, "path": "/var/archivematica/sharedDirectory/www/DIPsStore",
+        "pipeline": ["/api/v2/pipeline/1ffc9650-4862-4e53-a4f1-9c7e2a26ab72/"], "purpose":
+        "DS", "quota": null, "relative_path": "var/archivematica/sharedDirectory/www/DIPsStore",
+        "resource_uri": "/api/v2/location/b7783482-a2ca-4dc8-9f3e-6305c7569268/",
+        "space": "/api/v2/space/f18ad8dd-9082-4f5c-bc67-b976e370fa90/", "used": "0",
+        "uuid": "b7783482-a2ca-4dc8-9f3e-6305c7569268"}, {"description": "Default
+        transfer backlog", "enabled": true, "path": "/var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog",
+        "pipeline": ["/api/v2/pipeline/1ffc9650-4862-4e53-a4f1-9c7e2a26ab72/"], "purpose":
+        "BL", "quota": null, "relative_path": "var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog",
+        "resource_uri": "/api/v2/location/77dd226a-39b2-4217-b2a4-e17dad1beaae/",
+        "space": "/api/v2/space/f18ad8dd-9082-4f5c-bc67-b976e370fa90/", "used": "0",
+        "uuid": "77dd226a-39b2-4217-b2a4-e17dad1beaae"}, {"description": "For storage
+        service internal usage.", "enabled": true, "path": "/var/archivematica/storage_service",
+        "pipeline": [], "purpose": "SS", "quota": null, "relative_path": "var/archivematica/storage_service",
+        "resource_uri": "/api/v2/location/e8f346b7-0090-44b5-8b31-bff7f9d74e98/",
+        "space": "/api/v2/space/f18ad8dd-9082-4f5c-bc67-b976e370fa90/", "used": "0",
+        "uuid": "e8f346b7-0090-44b5-8b31-bff7f9d74e98"}, {"description": "Default
+        AIP recovery", "enabled": true, "path": "/var/archivematica/storage_service/recover",
+        "pipeline": ["/api/v2/pipeline/1ffc9650-4862-4e53-a4f1-9c7e2a26ab72/"], "purpose":
+        "AR", "quota": null, "relative_path": "var/archivematica/storage_service/recover",
+        "resource_uri": "/api/v2/location/52bea1a4-0853-4082-8a63-3540b79d1772/",
+        "space": "/api/v2/space/f18ad8dd-9082-4f5c-bc67-b976e370fa90/", "used": "0",
+        "uuid": "52bea1a4-0853-4082-8a63-3540b79d1772"}, {"description": null, "enabled":
+        true, "path": "/var/archivematica/sharedDirectory", "pipeline": ["/api/v2/pipeline/1ffc9650-4862-4e53-a4f1-9c7e2a26ab72/"],
+        "purpose": "CP", "quota": null, "relative_path": "var/archivematica/sharedDirectory/",
+        "resource_uri": "/api/v2/location/4fdc5235-40cd-4b73-b63a-8df54e037061/",
+        "space": "/api/v2/space/f18ad8dd-9082-4f5c-bc67-b976e370fa90/", "used": "0",
+        "uuid": "4fdc5235-40cd-4b73-b63a-8df54e037061"}]}'}
+    headers:
+      cache-control: [no-cache]
+      connection: [keep-alive]
+      content-language: [en]
+      content-type: [application/json]
+      date: ['Tue, 26 Feb 2019 10:39:44 GMT']
+      server: [nginx/1.14.2]
+      transfer-encoding: [chunked]
+      vary: ['Accept, Accept-Language, Cookie']
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/fixtures/vcr_cassettes/test_package_endpoint.yaml
+++ b/fixtures/vcr_cassettes/test_package_endpoint.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"name": "amclient-transfer", "path": "ZDExODRmN2YtZDc1NS00YzhkLTgzMWEtYTM3OTNiODhmNzYwOi9hcmNoaXZlbWF0aWNhL2FyY2hpdmVtYXRpY2Etc2FtcGxlZGF0YS9TYW1wbGVUcmFuc2ZlcnMvRGVtb1RyYW5zZmVy",
+      "processing_config": "automated"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: ['ApiKey test:3c23b0361887ace72b9d42963d9acbdf06644673']
+      Connection: [keep-alive]
+      Content-Length: ['215']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192/api/v2beta/package/
+  response:
+    body: {string: '{"id": "8e6259a0-34c8-4514-be3c-18dc0d42ce1c"}'}
+    headers:
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Wed, 27 Feb 2019 13:15:30 GMT']
+      Server: [nginx/1.14.2]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept-Language, Cookie']
+    status: {code: 202, message: ACCEPTED}
+- request:
+    body: '{"name": "amclient-transfer", "path": "L2hvbWUvYXJjaGl2ZW1hdGljYS9hcmNoaXZlbWF0aWNhLXNhbXBsZWRhdGEvU2FtcGxlVHJhbnNmZXJzL0RlbW9UcmFuc2Zlcg==",
+      "processing_config": "automated"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: ['ApiKey test:3c23b0361887ace72b9d42963d9acbdf06644673']
+      Connection: [keep-alive]
+      Content-Length: ['175']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://192.168.168.192/api/v2beta/package/
+  response:
+    body: {string: '{"id": "8b15874d-d411-4bb7-adb3-eba300a3ef1e"}'}
+    headers:
+      Connection: [keep-alive]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Wed, 27 Feb 2019 13:15:30 GMT']
+      Server: [nginx/1.14.2]
+      Transfer-Encoding: [chunked]
+      Vary: ['Accept-Language, Cookie']
+    status: {code: 202, message: ACCEPTED}
+version: 1

--- a/transfers/amclientargs.py
+++ b/transfers/amclientargs.py
@@ -15,7 +15,6 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from transfers import defaults
-from transfers.utils import fsencode
 
 
 # Reusable argument constants (for CLI).
@@ -60,6 +59,10 @@ TRANSFER_DIRECTORY = Arg(
     name="transfer_directory",
     help="Directory of a potential Archivematica transfer",
     type=None)
+RELATIVE_PATH = Arg(
+    name="relative_path",
+    help="Relative path to a file in an Archivematica package",
+    type=None)
 
 # Reusable option constants (for CLI).
 Opt = namedtuple('Opt', ['name', 'metavar', 'help', 'default', 'type'])
@@ -78,7 +81,7 @@ AM_USER_NAME = Opt(
 DIRECTORY = Opt(
     name='directory',
     metavar='DIR',
-    help='Directory path to save the DIP in',
+    help='Directory path to save the package in',
     default=None,
     type=None)
 OUTPUT_MODE = Opt(
@@ -104,8 +107,8 @@ TRANSFER_PATH = Opt(
     name='transfer-path',
     metavar='PATH',
     help='Relative path within the Transfer Source. Default: ""',
-    default=b'',
-    type=fsencode)
+    default="",
+    type=None)
 PROCESSING_CONFIG = Opt(
     name='processing-config',
     metavar='PROCESSING',
@@ -126,6 +129,24 @@ TRANSFER_TYPE = Opt(
     help='Reingest type. Default: {0}'.format(
         defaults.DEFAULT_TRANSFER_TYPE),
     default=defaults.DEFAULT_TRANSFER_TYPE,
+    type=None)
+TRANSFER_SOURCE_OPT = Opt(
+    name='transfer-source',
+    metavar='TRANSFERSOURCE',
+    help='Transfer source UUID',
+    default=None,
+    type=None)
+SAVEAS_FILENAME = Opt(
+    name="saveas-filename",
+    metavar='SAVEASFILENAME',
+    help="A filename to save an extracted file as",
+    default=None,
+    type=None)
+TRANSFER_NAME = Opt(
+    name="transfer-name",
+    metavar='TRANSFERNAME',
+    help="A name for the transfer",
+    default="amclient-transfer",
     type=None)
 
 # Sub-command configuration: give them a name, help text, a tuple of ``Arg``
@@ -207,6 +228,12 @@ SUBCOMMANDS = (
         opts=(SS_USER_NAME, SS_URL, DIRECTORY, OUTPUT_MODE)
     ),
     SubCommand(
+        name='download-aip',
+        help='Download the AIP with AIP_UUID.',
+        args=(AIP_UUID, SS_API_KEY),
+        opts=(SS_USER_NAME, SS_URL, DIRECTORY, OUTPUT_MODE)
+    ),
+    SubCommand(
         name='get-pipelines',
         help='List (enabled) Pipelines known to the Storage Service.',
         args=(SS_API_KEY,),
@@ -247,7 +274,25 @@ SUBCOMMANDS = (
         help='Retrieve details about a package in the storage service with a given UUID.',
         args=(PACKAGE_UUID, SS_API_KEY),
         opts=(SS_USER_NAME, SS_URL, OUTPUT_MODE)
-    )
+    ),
+    SubCommand(
+        name='list-storage-locations',
+        help='Retrieve a list of storage service locations.',
+        args=(SS_API_KEY,),
+        opts=(SS_USER_NAME, SS_URL, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='create-package',
+        help='Start and approve the processing of a transfer package.',
+        args=(AM_API_KEY, TRANSFER_DIRECTORY),
+        opts=(AM_USER_NAME, AM_URL, TRANSFER_SOURCE_OPT, TRANSFER_NAME, PROCESSING_CONFIG, OUTPUT_MODE)
+    ),
+    SubCommand(
+        name='extract-file',
+        help='Extract a file from a package in the storage service.',
+        args=(SS_API_KEY, PACKAGE_UUID, RELATIVE_PATH),
+        opts=(SS_USER_NAME, SS_URL, DIRECTORY, SAVEAS_FILENAME)
+    ),
 )
 
 


### PR DESCRIPTION
This PR adds three new capabilities to `amclient.py`: 

* List storage locations
* Create package
* Extract file relative to path of an AIP

Functionality has been integrated with the client, i.e. it isn't just module capability. Tests have been provided, but we might want to improve on those as the Sprints involved in this work progress. 

For the reviewer, if there are any nice-to-have's then we might consider a new issue and PR in future as this work seeks to satisfy the initial requirements of the Wellcome AMAUAT work. 

Connected to archivematica/issues#478
Connected to archivematica/issues#510
Connected to archivematica/issues#509

Examples of CLI usage below:

Most are based on DemoTransfer in the SampleData repository, UUIDs, passwords, urls, and transfer names need to be replaced appropriately.

**Extract file CLI example:**
```bash
python -m transfers.amclient extract-file \
    test \
    2ad1bf0d-23fa-44e0-a128-9feadfe22c42 \
    amclient-transfer_1-2ad1bf0d-23fa-44e0-a128-9feadfe22c42/data/objects/bird.mp3  \
    --ss-user-name test \
    --ss-url http://127.0.0.1:62081 \
    --saveas-filename myfilename --directory mydirectory
```

**Create package CLI example:**
```bash
python3 -m transfers.amclient create-package \
    test \
    "/archivematica/archivematica-sampledata/SampleTransfers/DemoTransfer" \
    --am-user-name test \
    --am-url http://127.0.0.1:62080 \
    --transfer-source 6e93c5b8-0ba3-4b54-9648-00ed3187d410 \
    --processing-config automated --transfer-name mytransfername
```
```bash
python3 -m transfers.amclient create-package \
    test \
    "/home/archivematica/archivematica-sampledata/SampleTransfers/DemoTransfer" \
    --am-user-name test \
    --am-url http://127.0.0.1:62080 \
    --processing-config automated \
    --transfer-name mytransfername
```

**Retrieve storage service locations example:**
```bash
python -m transfers.amclient list-storage-locations \
    --ss-user-name test test
```