### PR TITLE
Create DIP: support PREMIS 2.2 and 3.0 namespaces

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 amclient==1.0.0rc2
-metsrw==0.2.0
+metsrw==0.3.8
 requests<3.0
 sqlalchemy
 six


### PR DESCRIPTION
Upgrading `metsrw` was not required but it's the only script using it and it works in both versions.

https://github.com/archivematica/Issues/issues/653