### PR TITLE
Add DIP upload to SS script

### DIFF
--- a/dips/atom_upload.py
+++ b/dips/atom_upload.py
@@ -12,19 +12,20 @@ import logging
 import logging.config  # Has to be imported separately
 import os
 import subprocess
+import shutil
 import sys
 
 import requests
 
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-LOGGER = logging.getLogger("atom_upload")
+LOGGER = logging.getLogger("dip_workflow")
 
 
 def setup_logger(log_file, log_level="INFO"):
     """Configures the logger to output to console and log file"""
     if not log_file:
-        log_file = os.path.join(THIS_DIR, "atom_upload.log")
+        log_file = os.path.join(THIS_DIR, "dip_workflow.log")
 
     CONFIG = {
         "version": 1,
@@ -46,14 +47,22 @@ def setup_logger(log_file, log_level="INFO"):
             },
         },
         "loggers": {
-            "atom_upload": {"level": log_level, "handlers": ["console", "file"]}
+            "dip_workflow": {"level": log_level, "handlers": ["console", "file"]}
         },
     }
 
     logging.config.dictConfig(CONFIG)
 
 
-def main(atom_url, atom_email, atom_password, atom_slug, rsync_target, dip_path):
+def main(
+    atom_url,
+    atom_email,
+    atom_password,
+    atom_slug,
+    rsync_target,
+    dip_path,
+    delete_local_copy,
+):
     """Sends the DIP to the AtoM host and a deposit request to the AtoM instance"""
     LOGGER.info("Starting DIP upload to AtoM from: %s", dip_path)
 
@@ -72,6 +81,13 @@ def main(atom_url, atom_email, atom_password, atom_slug, rsync_target, dip_path)
         return 2
 
     LOGGER.info("DIP deposited in AtoM")
+
+    if delete_local_copy:
+        LOGGER.info("Deleting local DIP.")
+        try:
+            shutil.rmtree(dip_path)
+        except (OSError, shutil.Error) as e:
+            LOGGER.warning("DIP removal failed: %s", e)
 
 
 def rsync(rsync_target, dip_path):
@@ -144,10 +160,7 @@ if __name__ == "__main__":
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--atom-url",
-        metavar="URL",
-        help="AtoM instance URL. Default: http://192.168.168.193",
-        default="http://192.168.168.193",
+        "--atom-url", metavar="URL", required=True, help="AtoM instance URL."
     )
     parser.add_argument(
         "--atom-email",
@@ -170,14 +183,19 @@ if __name__ == "__main__":
     parser.add_argument(
         "--rsync-target",
         metavar="HOST:PATH",
-        help="Destination value passed to Rsync. Default: 192.168.168.193:/tmp.",
-        default="192.168.168.193:/tmp",
+        required=True,
+        help="Destination value passed to Rsync.",
     )
     parser.add_argument(
         "--dip-path",
         metavar="PATH",
         required=True,
         help="Absolute path to the DIP to upload.",
+    )
+    parser.add_argument(
+        "--delete-local-copy",
+        action="store_true",
+        help="Deletes the local DIP after upload.",
     )
 
     # Logging
@@ -222,5 +240,6 @@ if __name__ == "__main__":
             atom_slug=args.atom_slug,
             rsync_target=args.rsync_target,
             dip_path=args.dip_path,
+            delete_local_copy=args.delete_local_copy,
         )
     )

--- a/dips/storage_service_upload.py
+++ b/dips/storage_service_upload.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+"""
+Uploads a DIP to an Storage Service instance.
+
+Uploads a local DIP to a DIP storage location in an SS instance.
+Requires access to a pipeline's currently processing location path (the
+shared path), to move the DIP folder in there and send a requests to the
+Storage Service to process that DIP and create a relationship with the
+AIP from where it was created.
+"""
+
+import argparse
+import logging
+import logging.config  # Has to be imported separately
+import os
+import shutil
+import sys
+import time
+import uuid
+
+import requests
+
+
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+LOGGER = logging.getLogger("dip_workflow")
+
+
+def setup_logger(log_file, log_level="INFO"):
+    """Configures the logger to output to console and log file"""
+    if not log_file:
+        log_file = os.path.join(THIS_DIR, "dip_workflow.log")
+
+    CONFIG = {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "default": {
+                "format": "%(levelname)-8s  %(asctime)s  %(message)s",
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+            }
+        },
+        "handlers": {
+            "console": {"class": "logging.StreamHandler", "formatter": "default"},
+            "file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "default",
+                "filename": log_file,
+                "backupCount": 2,
+                "maxBytes": 10 * 1024,
+            },
+        },
+        "loggers": {
+            "dip_workflow": {"level": log_level, "handlers": ["console", "file"]}
+        },
+    }
+
+    logging.config.dictConfig(CONFIG)
+
+
+def main(
+    ss_url,
+    ss_user,
+    ss_api_key,
+    pipeline_uuid,
+    cp_location_uuid,
+    ds_location_uuid,
+    shared_directory,
+    dip_path,
+    aip_uuid,
+    delete_local_copy,
+):
+    # Move DIP to the currently processing location path, do not use any of the
+    # existing watched directories as that may trigger other workflows.
+    at_dips_dir = os.path.join(
+        shared_directory, "watchedDirectories", "automationToolsDIPs"
+    )
+    if not os.path.exists(at_dips_dir):
+        os.makedirs(at_dips_dir)
+    upload_dir_name = os.path.basename(dip_path)
+    upload_dip_dir = os.path.join(at_dips_dir, upload_dir_name)
+
+    # Stop if the DIP already exists in the shared directory
+    if os.path.exists(upload_dip_dir):
+        LOGGER.error("A directory already exists for the DIP in: %s" % upload_dip_dir)
+        return 1
+
+    try:
+        shutil.copytree(dip_path, upload_dip_dir)
+    except (OSError, shutil.Error) as e:
+        LOGGER.warning("Could not move DIP to currently processing path: %s", e)
+        return 2
+
+    # Build DIP data for SS request
+    size = 0
+    for dirpath, _, filenames in os.walk(upload_dip_dir):
+        for filename in filenames:
+            file_path = os.path.join(dirpath, filename)
+            size += os.path.getsize(file_path)
+    dip_data = {
+        "uuid": str(uuid.uuid4()),  # new UUID
+        "origin_pipeline": "/api/v2/pipeline/%s/" % pipeline_uuid,
+        "origin_location": "/api/v2/location/%s/" % cp_location_uuid,
+        "origin_path": "watchedDirectories/automationToolsDIPs/%s/" % upload_dir_name,
+        "current_location": "/api/v2/location/%s/" % ds_location_uuid,
+        "current_path": upload_dir_name,
+        "package_type": "DIP",
+        "aip_subtype": "Archival Information Package",  # same as in AM
+        "size": size,
+        "related_package_uuid": aip_uuid,
+        "events": [],
+        "agents": [],
+    }
+    # SS 'file/async/' POST request.
+    # TODO: Move this to amclient.
+    url = "%s/api/v2/file/async/" % ss_url
+    headers = {"Authorization": "ApiKey %s:%s" % (ss_user, ss_api_key)}
+    response = requests.post(url, headers=headers, json=dip_data, timeout=5)
+    result = 0
+    if (
+        response.status_code != requests.codes.accepted
+        or "Location" not in response.headers
+    ):
+        LOGGER.error("Could not store DIP in SS: %s", response.text)
+        result = 3
+    else:
+        LOGGER.info("Storing DIP in SS.")
+        try:
+            ret = check_async(response.headers["Location"], headers=headers)
+            if not ret:
+                LOGGER.warning("Timeout checking the DIP storage result.")
+            else:
+                LOGGER.info("DIP stored.")
+                if "uuid" in ret:
+                    LOGGER.info("SS UUID: %s" % ret["uuid"])
+
+        except requests.exceptions.RequestException as e:
+            LOGGER.error("Could not store DIP in SS: %s", e)
+            result = 4
+
+    # Finally remove the DIP from the currently processing location
+    LOGGER.info("Removing duplicates.")
+    try:
+        shutil.rmtree(upload_dip_dir)
+    except (OSError, shutil.Error) as e:
+        LOGGER.warning("Duplicates removal failed: %s", e)
+
+    # And remove the local copy if requested
+    if delete_local_copy:
+        LOGGER.info("Deleting local DIP.")
+        try:
+            shutil.rmtree(dip_path)
+        except (OSError, shutil.Error) as e:
+            LOGGER.warning("DIP removal failed: %s", e)
+
+    return result
+
+
+def check_async(url, headers={}, tries=60, interval=10):
+    for _ in range(tries):
+        response = requests.get(url, headers=headers, timeout=5)
+        response.raise_for_status()
+        payload = response.json()
+        if not payload["completed"]:
+            time.sleep(interval)
+            continue
+        if payload["was_error"]:
+            raise requests.exceptions.RequestException(payload["error"])
+        return payload["result"]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--ss-url",
+        metavar="URL",
+        help="Storage Service URL. Default: http://127.0.0.1:8000",
+        default="http://127.0.0.1:8000",
+    )
+    parser.add_argument(
+        "--ss-user",
+        metavar="USERNAME",
+        required=True,
+        help="Username of the Storage Service user to authenticate as.",
+    )
+    parser.add_argument(
+        "--ss-api-key",
+        metavar="KEY",
+        required=True,
+        help="API key of the Storage Service user.",
+    )
+    parser.add_argument(
+        "--pipeline-uuid",
+        metavar="UUID",
+        required=True,
+        help="UUID of the Archivemativa pipeline in the Storage Service",
+    )
+    parser.add_argument(
+        "--cp-location-uuid",
+        metavar="UUID",
+        required=True,
+        help="UUID of the pipeline's Currently Processing location in the Storage Service",
+    )
+    parser.add_argument(
+        "--ds-location-uuid",
+        metavar="UUID",
+        required=True,
+        help="UUID of the pipeline's DIP storage location in the Storage Service",
+    )
+    parser.add_argument(
+        "--shared-directory",
+        metavar="PATH",
+        help="Absolute path to the pipeline's shared directory.",
+        default="/var/archivematica/sharedDirectory/",
+    )
+    parser.add_argument(
+        "--dip-path",
+        metavar="PATH",
+        required=True,
+        help="Absolute path to the DIP to upload.",
+    )
+    parser.add_argument(
+        "--aip-uuid", metavar="UUID", required=True, help="UUID of the related AIP"
+    )
+    parser.add_argument(
+        "--delete-local-copy",
+        action="store_true",
+        help="Deletes the local DIP after upload.",
+    )
+
+    # Logging
+    parser.add_argument(
+        "--log-file", metavar="FILE", help="Location of log file", default=None
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="count",
+        default=0,
+        help="Increase the debugging output.",
+    )
+    parser.add_argument(
+        "--quiet", "-q", action="count", default=0, help="Decrease the debugging output"
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["ERROR", "WARNING", "INFO", "DEBUG"],
+        default=None,
+        help="Set the debugging output level. This will override -q and -v",
+    )
+
+    args = parser.parse_args()
+
+    log_levels = {2: "ERROR", 1: "WARNING", 0: "INFO", -1: "DEBUG"}
+    if args.log_level is None:
+        level = args.quiet - args.verbose
+        level = max(level, -1)  # No smaller than -1
+        level = min(level, 2)  # No larger than 2
+        log_level = log_levels[level]
+    else:
+        log_level = args.log_level
+
+    setup_logger(args.log_file, log_level)
+
+    sys.exit(
+        main(
+            ss_url=args.ss_url,
+            ss_user=args.ss_user,
+            ss_api_key=args.ss_api_key,
+            pipeline_uuid=args.pipeline_uuid,
+            cp_location_uuid=args.cp_location_uuid,
+            ds_location_uuid=args.ds_location_uuid,
+            shared_directory=args.shared_directory,
+            dip_path=args.dip_path,
+            aip_uuid=args.aip_uuid,
+            delete_local_copy=args.delete_local_copy,
+        )
+    )

--- a/fixtures/vcr_cassettes/test_storage_service_upload_async_fail.yaml
+++ b/fixtures/vcr_cassettes/test_storage_service_upload_async_fail.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"uuid": "468b8ed1-b6b7-44a7-897f-e57fc7c49308", "origin_pipeline": "/api/v2/pipeline/88050c7f-36a3-4900-9294-5a0411d69303/",
+      "origin_location": "/api/v2/location/e6409b38-20e9-4739-bb4a-892f2fb300d3/",
+      "origin_path": "watchedDirectories/uploadDIP/fake_DIP/", "current_location":
+      "/api/v2/location/6bbd3dee-b52f-476f-8136-bb3f0d025096/", "current_path": "fake_DIP",
+      "package_type": "DIP", "aip_subtype": "Archival Information Package", "size":
+      0, "related_package_uuid": "b9cd796c-2231-42e6-9cd1-0236d22958fa", "events":
+      [], "agents": []}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '538'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: POST
+    uri: http://localhost:62081/api/v2/file/async/
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 09 May 2019 22:03:03 GMT
+      Location:
+      - http://localhost:62081/api/v2/async/23/
+      Server:
+      - nginx/1.14.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 202
+      message: ACCEPTED
+version: 1

--- a/fixtures/vcr_cassettes/test_storage_service_upload_request_fail.yaml
+++ b/fixtures/vcr_cassettes/test_storage_service_upload_request_fail.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"uuid": "755dee19-b589-4e9b-9d6f-a8d4ad7497db", "origin_pipeline": "/api/v2/pipeline/88050c7f-36a3-4900-9294-5a0411d69303/",
+      "origin_location": "/api/v2/location/e6409b38-20e9-4739-bb4a-892f2fb300d3/",
+      "origin_path": "watchedDirectories/uploadDIP/fake_DIP/", "current_location":
+      "/api/v2/location/6bbd3dee-b52f-476f-8136-bb3f0d025096/", "current_path": "fake_DIP",
+      "package_type": "DIP", "aip_subtype": "Archival Information Package", "size":
+      0, "related_package_uuid": "b9cd796c-2231-42e6-9cd1-0236d22958fa", "events":
+      [], "agents": []}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:fake_api_key
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '538'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: POST
+    uri: http://localhost:62081/api/v2/file/async/
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 09 May 2019 22:03:03 GMT
+      Server:
+      - nginx/1.14.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Language, Cookie
+      WWW-Authenticate:
+      - Basic Realm="django-tastypie"
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 401
+      message: UNAUTHORIZED
+version: 1

--- a/fixtures/vcr_cassettes/test_storage_service_upload_success.yaml
+++ b/fixtures/vcr_cassettes/test_storage_service_upload_success.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"uuid": "e759c5e6-efd0-4996-863e-0f881d7d0b52", "origin_pipeline": "/api/v2/pipeline/88050c7f-36a3-4900-9294-5a0411d69303/",
+      "origin_location": "/api/v2/location/e6409b38-20e9-4739-bb4a-892f2fb300d3/",
+      "origin_path": "watchedDirectories/uploadDIP/fake_DIP/", "current_location":
+      "/api/v2/location/6bbd3dee-b52f-476f-8136-bb3f0d025096/", "current_path": "fake_DIP",
+      "package_type": "DIP", "aip_subtype": "Archival Information Package", "size":
+      0, "related_package_uuid": "b9cd796c-2231-42e6-9cd1-0236d22958fa", "events":
+      [], "agents": []}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '538'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: POST
+    uri: http://localhost:62081/api/v2/file/async/
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 09 May 2019 22:03:03 GMT
+      Location:
+      - http://localhost:62081/api/v2/async/24/
+      Server:
+      - nginx/1.14.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 202
+      message: ACCEPTED
+version: 1

--- a/tests/test_atom_upload.py
+++ b/tests/test_atom_upload.py
@@ -43,6 +43,7 @@ class TestAtomUpload(unittest.TestCase):
             ATOM_PASSWORD,
             ATOM_SLUG,
             DIP_PATH,
+            True,
         )
 
     @vcr.use_cassette("fixtures/vcr_cassettes/test_atom_upload_deposit_success.yaml")
@@ -57,7 +58,13 @@ class TestAtomUpload(unittest.TestCase):
         effect = subprocess.CalledProcessError(1, [])
         with mock.patch("dips.atom_upload.rsync", side_effect=effect):
             ret = atom_upload.main(
-                ATOM_URL, ATOM_EMAIL, ATOM_PASSWORD, ATOM_SLUG, RSYNC_TARGET, DIP_PATH
+                ATOM_URL,
+                ATOM_EMAIL,
+                ATOM_PASSWORD,
+                ATOM_SLUG,
+                RSYNC_TARGET,
+                DIP_PATH,
+                True,
             )
 
         assert ret == 1
@@ -67,17 +74,31 @@ class TestAtomUpload(unittest.TestCase):
         deposit_fail = mock.patch("dips.atom_upload.deposit", side_effect=Exception(""))
         with rsync_success, deposit_fail:
             ret = atom_upload.main(
-                ATOM_URL, ATOM_EMAIL, ATOM_PASSWORD, ATOM_SLUG, RSYNC_TARGET, DIP_PATH
+                ATOM_URL,
+                ATOM_EMAIL,
+                ATOM_PASSWORD,
+                ATOM_SLUG,
+                RSYNC_TARGET,
+                DIP_PATH,
+                True,
             )
 
         assert ret == 2
 
-    def test_main_success(self):
+    @mock.patch("dips.atom_upload.shutil.rmtree")
+    def test_main_success(self, mock_rmtree):
         rsync_success = mock.patch("dips.atom_upload.rsync", return_value=None)
         deposit_success = mock.patch("dips.atom_upload.deposit", return_value=None)
         with rsync_success, deposit_success:
             ret = atom_upload.main(
-                ATOM_URL, ATOM_EMAIL, ATOM_PASSWORD, ATOM_SLUG, RSYNC_TARGET, DIP_PATH
+                ATOM_URL,
+                ATOM_EMAIL,
+                ATOM_PASSWORD,
+                ATOM_SLUG,
+                RSYNC_TARGET,
+                DIP_PATH,
+                True,
             )
 
+        mock_rmtree.assert_called_with(DIP_PATH)
         assert ret is None

--- a/tests/test_create_dip.py
+++ b/tests/test_create_dip.py
@@ -74,8 +74,8 @@ class TestCreateDip(unittest.TestCase):
             # Extract it
             aip_dir = create_dip.extract_aip(aip_path, AIP_UUID, TMP_DIR)
             # Test DIP creation
-            dip_dir = create_dip.create_dip(aip_dir, AIP_UUID, OUTPUT_DIR)
-            assert dip_dir == "{}/{}_{}_DIP".format(OUTPUT_DIR, TRANSFER_NAME, AIP_UUID)
+            dip_dir = create_dip.create_dip(aip_dir, AIP_UUID, OUTPUT_DIR, "atom")
+            assert dip_dir == "{}/{}-{}".format(OUTPUT_DIR, TRANSFER_NAME, AIP_UUID)
             assert os.path.isdir(dip_dir)
             # Check a METS file exists
             dip_mets = "{}/METS.{}.xml".format(dip_dir, AIP_UUID)
@@ -128,5 +128,5 @@ class TestCreateDip(unittest.TestCase):
 
     def test_create_dip_fail_no_aip_dir(self):
         """Test that a DIP creation fails with a bad path."""
-        dip_dir = create_dip.create_dip("bad_path", AIP_UUID, OUTPUT_DIR)
+        dip_dir = create_dip.create_dip("bad_path", AIP_UUID, OUTPUT_DIR, "atom")
         assert dip_dir is None

--- a/tests/test_create_dips_job.py
+++ b/tests/test_create_dips_job.py
@@ -26,6 +26,28 @@ DATABASE_FILE = os.path.join(TMP_DIR, "aips.db")
 
 
 class TestCreateDipsJob(unittest.TestCase):
+    def setUp(self):
+        self.args = {
+            "ss_url": SS_URL,
+            "ss_user": SS_USER_NAME,
+            "ss_api_key": SS_API_KEY,
+            "location_uuid": LOCATION_UUID,
+            "tmp_dir": TMP_DIR,
+            "output_dir": OUTPUT_DIR,
+            "database_file": DATABASE_FILE,
+            "delete_local_copy": True,
+            "upload_type": None,
+            "pipeline_uuid": "",
+            "cp_location_uuid": "",
+            "ds_location_uuid": "",
+            "shared_directory": "",
+            "atom_url": "",
+            "atom_email": "",
+            "atom_password": "",
+            "atom_slug": "",
+            "rsync_target": "",
+        }
+
     def test_filter_aips(self):
         """
         Test that AIPs without 'uuid' or 'current_location'
@@ -50,48 +72,26 @@ class TestCreateDipsJob(unittest.TestCase):
 
     def test_main_fail_db(self):
         """Test a fail when a database can't be created."""
-        ret = create_dips_job.main(
-            SS_URL,
-            SS_USER_NAME,
-            SS_API_KEY,
-            LOCATION_UUID,
-            TMP_DIR,
-            OUTPUT_DIR,
-            "/this/should/be/a/wrong/path/to.db",
-        )
+        self.args["database_file"] = "/this/should/be/a/wrong/path/to.db"
+        ret = create_dips_job.main(**self.args)
         assert ret == 1
 
     @vcr.use_cassette("fixtures/vcr_cassettes/create_dips_job_main_fail_request.yaml")
     def test_main_fail_request(self):
         """Test a fail when an SS connection can't be established."""
         with TmpDir(TMP_DIR):
-            ret = create_dips_job.main(
-                SS_URL,
-                SS_USER_NAME,
-                "bad_api_key",
-                LOCATION_UUID,
-                TMP_DIR,
-                OUTPUT_DIR,
-                DATABASE_FILE,
-            )
+            self.args["ss_api_key"] = "bad_api_key"
+            ret = create_dips_job.main(**self.args)
             assert ret == 2
 
     @vcr.use_cassette("fixtures/vcr_cassettes/create_dips_job_main_success.yaml")
     def test_main_success(self):
         """Test a success where one DIP is created."""
         with TmpDir(TMP_DIR), TmpDir(OUTPUT_DIR):
-            ret = create_dips_job.main(
-                SS_URL,
-                SS_USER_NAME,
-                SS_API_KEY,
-                LOCATION_UUID,
-                TMP_DIR,
-                OUTPUT_DIR,
-                DATABASE_FILE,
-            )
+            ret = create_dips_job.main(**self.args)
             assert ret is None
             dip_path = os.path.join(
-                OUTPUT_DIR, "test_B_3ea465ac-ea0a-4a9c-a057-507e794de332_DIP"
+                OUTPUT_DIR, "test_B-3ea465ac-ea0a-4a9c-a057-507e794de332"
             )
             assert os.path.isdir(dip_path)
 
@@ -101,17 +101,58 @@ class TestCreateDipsJob(unittest.TestCase):
         effect = exc.IntegrityError({}, [], "")
         session_add_patch = mock.patch("sqlalchemy.orm.Session.add", side_effect=effect)
         with TmpDir(TMP_DIR), TmpDir(OUTPUT_DIR), session_add_patch:
-            ret = create_dips_job.main(
-                SS_URL,
-                SS_USER_NAME,
-                SS_API_KEY,
-                LOCATION_UUID,
-                TMP_DIR,
-                OUTPUT_DIR,
-                DATABASE_FILE,
-            )
+            ret = create_dips_job.main(**self.args)
             assert ret is None
             dip_path = os.path.join(
-                OUTPUT_DIR, "test_B_3ea465ac-ea0a-4a9c-a057-507e794de332_DIP"
+                OUTPUT_DIR, "test_B-3ea465ac-ea0a-4a9c-a057-507e794de332"
             )
             assert not os.path.isdir(dip_path)
+
+    @vcr.use_cassette("fixtures/vcr_cassettes/create_dips_job_main_success.yaml")
+    @mock.patch("aips.create_dips_job.atom_upload.main")
+    @mock.patch("aips.create_dips_job.create_dip.main", return_value=1)
+    def test_main_dip_creation_failed(self, mock_create_dip, mock_atom_upload):
+        """Test that a fail on DIP creation doesn't trigger an upload."""
+        with TmpDir(TMP_DIR), TmpDir(OUTPUT_DIR):
+            self.args["upload_type"] = "atom-upload"
+            create_dips_job.main(**self.args)
+            assert not mock_atom_upload.called
+
+    @vcr.use_cassette("fixtures/vcr_cassettes/create_dips_job_main_success.yaml")
+    @mock.patch("aips.create_dips_job.atom_upload.main", return_value=None)
+    @mock.patch("aips.create_dips_job.create_dip.main", return_value="fake/path")
+    def test_main_success_atom_upload_call(self, mock_create_dip, mock_atom_upload):
+        """Test that an upload to AtoM is performed."""
+        with TmpDir(TMP_DIR), TmpDir(OUTPUT_DIR):
+            self.args.update(
+                {
+                    "upload_type": "atom-upload",
+                    "atom_url": "",
+                    "atom_email": "",
+                    "atom_password": "",
+                    "atom_slug": "",
+                    "rsync_target": "",
+                    "delete_local_copy": True,
+                }
+            )
+            create_dips_job.main(**self.args)
+            assert mock_atom_upload.called
+
+    @vcr.use_cassette("fixtures/vcr_cassettes/create_dips_job_main_success.yaml")
+    @mock.patch("aips.create_dips_job.storage_service_upload.main", return_value=None)
+    @mock.patch("aips.create_dips_job.create_dip.main", return_value="fake/path")
+    def test_main_success_ss_upload_call(self, mock_create_dip, mock_ss_upload):
+        """Test that an upload to AtoM is performed."""
+        with TmpDir(TMP_DIR), TmpDir(OUTPUT_DIR):
+            self.args.update(
+                {
+                    "upload_type": "ss-upload",
+                    "pipeline_uuid": "",
+                    "cp_location_uuid": "",
+                    "ds_location_uuid": "",
+                    "shared_directory": "",
+                    "delete_local_copy": True,
+                }
+            )
+            create_dips_job.main(**self.args)
+            assert mock_ss_upload.called

--- a/tests/test_storage_service_upload.py
+++ b/tests/test_storage_service_upload.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+import os
+import shutil
+import unittest
+import vcr
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import requests
+
+from dips import storage_service_upload
+
+SS_URL = "http://localhost:62081"
+SS_USER_NAME = "test"
+SS_API_KEY = "test"
+PIPELINE_UUID = "88050c7f-36a3-4900-9294-5a0411d69303"
+CP_LOCATION_UUID = "e6409b38-20e9-4739-bb4a-892f2fb300d3"
+DS_LOCATION_UUID = "6bbd3dee-b52f-476f-8136-bb3f0d025096"
+SHARED_DIRECTORY = "/home/radda/.am/am-pipeline-data/"
+DIP_PATH = "/tmp/fake_DIP"
+AIP_UUID = "b9cd796c-2231-42e6-9cd1-0236d22958fa"
+
+
+class TestSsUpload(unittest.TestCase):
+    @mock.patch("dips.storage_service_upload.os.path.exists", return_value=True)
+    def test_dip_folder_exists(self, mock_path_exists):
+        ret = storage_service_upload.main(
+            ss_url=SS_URL,
+            ss_user=SS_USER_NAME,
+            ss_api_key=SS_API_KEY,
+            pipeline_uuid=PIPELINE_UUID,
+            cp_location_uuid=CP_LOCATION_UUID,
+            ds_location_uuid=DS_LOCATION_UUID,
+            shared_directory=SHARED_DIRECTORY,
+            dip_path=DIP_PATH,
+            aip_uuid=AIP_UUID,
+            delete_local_copy=True,
+        )
+        assert ret == 1
+
+    @mock.patch(
+        "dips.storage_service_upload.shutil.copytree", side_effect=shutil.Error("")
+    )
+    @mock.patch("dips.storage_service_upload.os.makedirs")
+    def test_dip_folder_copy_fail(self, mock_makedirs, mock_copytree):
+        ret = storage_service_upload.main(
+            ss_url=SS_URL,
+            ss_user=SS_USER_NAME,
+            ss_api_key=SS_API_KEY,
+            pipeline_uuid=PIPELINE_UUID,
+            cp_location_uuid=CP_LOCATION_UUID,
+            ds_location_uuid=DS_LOCATION_UUID,
+            shared_directory=SHARED_DIRECTORY,
+            dip_path=DIP_PATH,
+            aip_uuid=AIP_UUID,
+            delete_local_copy=True,
+        )
+        assert ret == 2
+
+    @vcr.use_cassette(
+        "fixtures/vcr_cassettes/test_storage_service_upload_request_fail.yaml"
+    )
+    @mock.patch("dips.storage_service_upload.shutil.copytree")
+    @mock.patch("dips.storage_service_upload.os.makedirs")
+    def test_request_fail(self, mock_makedirs, mock_copytree):
+        ret = storage_service_upload.main(
+            ss_url=SS_URL,
+            ss_user=SS_USER_NAME,
+            ss_api_key="fake_api_key",
+            pipeline_uuid=PIPELINE_UUID,
+            cp_location_uuid=CP_LOCATION_UUID,
+            ds_location_uuid=DS_LOCATION_UUID,
+            shared_directory=SHARED_DIRECTORY,
+            dip_path=DIP_PATH,
+            aip_uuid=AIP_UUID,
+            delete_local_copy=True,
+        )
+        assert ret == 3
+
+    @vcr.use_cassette(
+        "fixtures/vcr_cassettes/test_storage_service_upload_async_fail.yaml"
+    )
+    @mock.patch(
+        "dips.storage_service_upload.check_async",
+        side_effect=requests.exceptions.RequestException(""),
+    )
+    @mock.patch("dips.storage_service_upload.shutil.copytree")
+    @mock.patch("dips.storage_service_upload.os.makedirs")
+    def test_async_fail(self, mock_makedirs, mock_copytree, mock_check_async):
+        ret = storage_service_upload.main(
+            ss_url=SS_URL,
+            ss_user=SS_USER_NAME,
+            ss_api_key=SS_API_KEY,
+            pipeline_uuid=PIPELINE_UUID,
+            cp_location_uuid=CP_LOCATION_UUID,
+            ds_location_uuid=DS_LOCATION_UUID,
+            shared_directory=SHARED_DIRECTORY,
+            dip_path=DIP_PATH,
+            aip_uuid=AIP_UUID,
+            delete_local_copy=True,
+        )
+        assert ret == 4
+
+    @vcr.use_cassette("fixtures/vcr_cassettes/test_storage_service_upload_success.yaml")
+    @mock.patch("dips.atom_upload.shutil.rmtree")
+    @mock.patch(
+        "dips.storage_service_upload.check_async", return_value={"uuid": "fake_uuid"}
+    )
+    @mock.patch("dips.storage_service_upload.shutil.copytree")
+    @mock.patch("dips.storage_service_upload.os.makedirs")
+    def test_success(self, mock_makedirs, mock_copytree, mock_check_async, mock_rmtree):
+        ret = storage_service_upload.main(
+            ss_url=SS_URL,
+            ss_user=SS_USER_NAME,
+            ss_api_key=SS_API_KEY,
+            pipeline_uuid=PIPELINE_UUID,
+            cp_location_uuid=CP_LOCATION_UUID,
+            ds_location_uuid=DS_LOCATION_UUID,
+            shared_directory=SHARED_DIRECTORY,
+            dip_path=DIP_PATH,
+            aip_uuid=AIP_UUID,
+            delete_local_copy=True,
+        )
+        assert ret == 0
+        upload_dip_path = os.path.join(
+            SHARED_DIRECTORY,
+            "watchedDirectories",
+            "automationToolsDIPs",
+            os.path.basename(DIP_PATH),
+        )
+        mock_rmtree.assert_has_calls([mock.call(upload_dip_path), mock.call(DIP_PATH)])


### PR DESCRIPTION
Uploads a local DIP to a DIP storage location in an SS instance.
Requires access to a pipeline's currently processing location path (the
shared path), to move the DIP folder in there and send a requests to the
Storage Service to process that DIP and create a relationship with the
AIP from where it was created.

Add METS type argument to `create_dip` script to choose between a
generated METS file that matches AtoM requirements for DIP upload and
copying the AIP's METS file directly, like the Storage Service does, to
be able to move the DIP to the SS. Defaults to AtoM METS for backwards
compatibility.

Allow to upload DIPs after creation in `create_dips_job`. Accept
different subsets of parameters and optionally upload the created DIPs
to AtoM or the Storage Service. Extend this script to make use of its
tracking functionality to create DIPs from all AIPs in a SS location.
Optionally delete the created DIPs after upload.

Use AIP folder name for DIP folder on creation to match what's currently
being done for DIPs stored in the SS.

Connects to https://github.com/archivematica/Issues/issues/688.

**All new parameters are optional, so this should not break any existing
setup, in the case of a repository upgrade and not changing how the
commands are executed.** The only noticeable change should be the DIP
folder name in those cases. I'll extend the existing docs from the README
on a different PR.