### PR TITLE
Restructure create_dip with additional Avalon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,10 +496,10 @@ uploads to the Storage Service.
 
 The optional `--dip-type` parameter will create a DIP structured in a specific
 way for different access systems. Presently, the only DIP Type available other
-than the default setting is the "avalon" option. This will create a DIP ready
-for batch ingest into the Avalon Media System, relying on the Transfer name to
-move files into a Collection folder and will append Archivematica-minted UUIDs
-to the root-level Manifest file.
+than the default setting is the "avalon-manifest" option. This will create a DIP
+ready for batch ingest into the Avalon Media System, relying on the Transfer
+name to move files into a Collection folder and will append Archivematica-minted
+UUIDs to the root-level Manifest file.
 
 While `aips/create_dip.py` only processes one AIP per execution,
 `aips/create_dips_job.py` will process all AIPs in a given Storage Service

--- a/README.md
+++ b/README.md
@@ -483,23 +483,24 @@ DIP creation and upload
 `aips/create_dip.py` and `aips/create_dips_job.py` can be used to make DIPs from
 AIPs available in a Storage Service instance. Unlike DIPs created in
 Archivematica, the ones created with this script will include only the original
-files from the transfer and they will maintain the directories, filenames and
-last modified date from those files. They will be placed with a copy of the
-submissionDocumentation folder (if present in the AIP) and the AIP METS file in
-a single ZIP file under the objects directory.
+files from the transfer and they will maintain the directories and filenames.
 
-Based on the `--mets-type` argument, another METS file will be generated
-alongside the objects folder containing only a reference to the ZIP file
-(without AMD or DMD sections), used to upload the DIP to an AtoM instance; or
-the same AIP METS file will be placed alongside the objects folder, used for
-uploads to the Storage Service.
+Based on the `--dip-type` parameter a few differences can be found in the
+resulting DIPs:
 
-The optional `--dip-type` parameter will create a DIP structured in a specific
-way for different access systems. Presently, the only DIP Type available other
-than the default setting is the "avalon-manifest" option. This will create a DIP
-ready for batch ingest into the Avalon Media System, relying on the Transfer
-name to move files into a Collection folder and will append Archivematica-minted
-UUIDs to the root-level Manifest file.
+* When using `zipped-objects`, the files will maintain the original last
+  modified date and they will be placed with a copy of the
+  submissionDocumentation folder and the AIP METS file in a single ZIP file
+  under the objects directory. Based on the `--mets-type` parameter, another
+  METS file will be generated alongside the objects folder containing only a
+  reference to the ZIP file (without AMD or DMD sections), used to upload the
+  DIP to an AtoM instance; or the same AIP METS file will be placed alongside
+  the objects folder, used for uploads to the Storage Service.
+* If `avalon-manifest` is used, the script will create a DIP ready for batch
+  ingest into the Avalon Media System, relying on the Transfer name to move
+  files into a Collection folder and will append Archivematica-minted UUIDs to
+  the root-level Manifest file. **Do not use this type of the DIP in conjunction
+  with the upload options explained below.**
 
 While `aips/create_dip.py` only processes one AIP per execution,
 `aips/create_dips_job.py` will process all AIPs in a given Storage Service
@@ -508,9 +509,9 @@ different subsets of parameters to automatically upload the created DIPs to the
 Storage Service or to an AtoM instance. Both scripts require 7z to be installed
 and available to extract the AIPs downloaded from the Storage Service.
 
-As mentioned, these DIPs can be uploaded to AtoM or the Storage Service using
-`dips.storage_service_upload` and `dips.atom_upload` or as part of the
-`aips/create_dips_job.py` execution.
+As mentioned, the "zipped-objects" DIPs can be uploaded to AtoM or the Storage
+Service using `dips.storage_service_upload` and `dips.atom_upload` or as part of
+the `aips/create_dips_job.py` execution.
 
 The AtoM upload requires a passwordless SSH connection to the AtoM host for the
 user running the script. The AtoM host must be added to list of known hosts.
@@ -567,8 +568,10 @@ similar scripts could be duplicated with a different set of parameters to call
   provided.
 * `--aip-uuid UUID` [REQUIRED]: AIP UUID in the Storage Service to create the
   DIP from.
-* `--dip-type TYPE`: Type of DIP to create. Default: zipped-objects."
-* `--mets-type TYPE`: Type of METS file to generate. Default: atom."
+* `--dip-type TYPE`: Type of DIP to create. Available options: "zipped-objects",
+  "avalon-manifest". Default: "zipped-objects".
+* `--mets-type TYPE`: Type of METS file to generate. Available options: "atom",
+  "storage-service". Default: "atom".
 * `--tmp-dir PATH`: Absolute path to a directory where the AIP(s) will be
   downloaded and extracted. Default: "/tmp"
 * `--output-dir PATH`: Absolute path to a directory where the DIP(s) will be

--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ similar scripts could be duplicated with a different set of parameters to call
   provided.
 * `--aip-uuid UUID` [REQUIRED]: AIP UUID in the Storage Service to create the
   DIP from.
+  * `--mets-type TYPE`: Type of DIP to create. Default: atom."
 * `--tmp-dir PATH`: Absolute path to a directory where the AIP(s) will be
   downloaded and extracted. Default: "/tmp"
 * `--output-dir PATH`: Absolute path to a directory where the DIP(s) will be

--- a/README.md
+++ b/README.md
@@ -486,11 +486,20 @@ Archivematica, the ones created with this script will include only the original
 files from the transfer and they will maintain the directories, filenames and
 last modified date from those files. They will be placed with a copy of the
 submissionDocumentation folder (if present in the AIP) and the AIP METS file in
-a single ZIP file under the objects directory. Based on the `--mets-type`
-argument, another METS file will be generated alongside the objects folder
-containing only a reference to the ZIP file (without AMD or DMD sections), used
-to upload the DIP to an AtoM instance; or the same AIP METS file will be placed
-alongside the objects folder, used for uploads to the Storage Service.
+a single ZIP file under the objects directory.
+
+Based on the `--mets-type` argument, another METS file will be generated
+alongside the objects folder containing only a reference to the ZIP file
+(without AMD or DMD sections), used to upload the DIP to an AtoM instance; or
+the same AIP METS file will be placed alongside the objects folder, used for
+uploads to the Storage Service.
+
+The optional `--dip-type` parameter will create a DIP structured in a specific
+way for different access systems. Presently, the only DIP Type available other
+than the default setting is the "avalon" option. This will create a DIP ready
+for batch ingest into the Avalon Media System, relying on the Transfer name to
+move files into a Collection folder and will append Archivematica-minted UUIDs
+to the root-level Manifest file.
 
 While `aips/create_dip.py` only processes one AIP per execution,
 `aips/create_dips_job.py` will process all AIPs in a given Storage Service
@@ -558,7 +567,8 @@ similar scripts could be duplicated with a different set of parameters to call
   provided.
 * `--aip-uuid UUID` [REQUIRED]: AIP UUID in the Storage Service to create the
   DIP from.
-  * `--mets-type TYPE`: Type of DIP to create. Default: atom."
+* `--dip-type TYPE`: Type of DIP to create. Default: default."
+* `--mets-type TYPE`: Type of METS file to generate. Default: atom."
 * `--tmp-dir PATH`: Absolute path to a directory where the AIP(s) will be
   downloaded and extracted. Default: "/tmp"
 * `--output-dir PATH`: Absolute path to a directory where the DIP(s) will be

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ similar scripts could be duplicated with a different set of parameters to call
   provided.
 * `--aip-uuid UUID` [REQUIRED]: AIP UUID in the Storage Service to create the
   DIP from.
-* `--dip-type TYPE`: Type of DIP to create. Default: default."
+* `--dip-type TYPE`: Type of DIP to create. Default: zipped-objects."
 * `--mets-type TYPE`: Type of METS file to generate. Default: atom."
 * `--tmp-dir PATH`: Absolute path to a directory where the AIP(s) will be
   downloaded and extracted. Default: "/tmp"

--- a/aips/create_dip.py
+++ b/aips/create_dip.py
@@ -258,15 +258,14 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type, dip_type):
     # Modify or copy METS file for DIP based on mets_type argument
     dip_mets_file = os.path.join(dip_dir, "METS.{}.xml".format(aip_uuid))
 
-    if mets_type == "atom":
-        create_dip_mets(aip_dir, aip_name, fsentries, mets, dip_mets_file)
-    elif mets_type == "storage-service":
-        copy_aip_mets(to_zip_mets_file, dip_mets_file)
-
     if dip_type == "avalon-manifest":
         # Update Manifest file with UUIDs
         update_avalon_manifest(dip_dir, aip_uuid)
     else:
+        if mets_type == "atom":
+            create_dip_mets(aip_dir, aip_name, fsentries, mets, dip_mets_file)
+        elif mets_type == "storage-service":
+            copy_aip_mets(to_zip_mets_file, dip_mets_file)
         compress_zip_folder(to_zip_dir)
         shutil.rmtree(to_zip_dir)
 

--- a/aips/create_dip.py
+++ b/aips/create_dip.py
@@ -182,7 +182,7 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type, dip_type):
     aip_dir_name = os.path.basename(aip_dir)
     aip_name = aip_dir_name[:-37]
 
-    if dip_type == "avalon":
+    if dip_type == "avalon-manifest":
         dip_dir = os.path.join(output_dir, aip_name, aip_uuid)
         to_zip_dir = dip_dir
     else:
@@ -196,7 +196,7 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type, dip_type):
 
     os.makedirs(to_zip_dir)
 
-    if dip_type != "avalon":
+    if dip_type != "avalon-manifest":
         move_sub_doc(aip_dir, to_zip_dir)
 
     LOGGER.info("Moving METS file")
@@ -249,7 +249,7 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type, dip_type):
 
         shutil.move(aip_file_path, dip_file_path)
 
-        if dip_type != "avalon":
+        if dip_type != "avalon-manifest":
             try:
                 set_fslastmodified(premis, namespaces, dip_file_path)
             except Exception:
@@ -260,13 +260,12 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type, dip_type):
 
     if mets_type == "atom":
         create_dip_mets(aip_dir, aip_name, fsentries, mets, dip_mets_file)
-    else:
+    elif mets_type == "storage-service":
         copy_aip_mets(to_zip_mets_file, dip_mets_file)
 
-    if dip_type == "avalon":
+    if dip_type == "avalon-manifest":
         # Update Manifest file with UUIDs
         update_avalon_manifest(dip_dir, aip_uuid)
-        os.remove(dip_mets_file)
     else:
         compress_zip_folder(to_zip_dir)
         shutil.rmtree(to_zip_dir)
@@ -472,9 +471,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--dip-type",
-        choices=["avalon", "storage-service"],
-        default="storage-service",
-        help="Structure DIP for specific systems. Default: storage-service.",
+        choices=["avalon-manifest", "zipped-objects"],
+        default="zipped-objects",
+        help="Structure DIP for specific systems. Default: zipped-objects.",
     )
     # Logging
     parser.add_argument(

--- a/aips/create_dip.py
+++ b/aips/create_dip.py
@@ -13,6 +13,7 @@ generated alongside the objects folder containing only a reference to the ZIP fi
 """
 
 import argparse
+import csv
 import logging
 import logging.config  # Has to be imported separately
 import os
@@ -165,26 +166,28 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type):
     :param str aip_dir: absolute path to an uncompressed AIP
     :param str aip_uuid: UUID from the AIP
     :param str output_dir: absolute path to a directory to place the DIP
+    :param str mets_type: type of METS to generate within DIP
     :returns: absolute path to the created DIP folder
     """
     aip_dir_name = os.path.basename(aip_dir)
     aip_name = aip_dir_name[:-37]
-    dip_dir = os.path.join(output_dir, aip_dir_name)
-    objects_dir = os.path.join(dip_dir, "objects")
-    to_zip_dir = os.path.join(objects_dir, aip_name)
+
+    if mets_type == "avalon":
+        dip_dir = os.path.join(output_dir, "{}/{}".format(aip_name, aip_uuid))
+        to_zip_dir = dip_dir
+    else:
+        dip_dir = os.path.join(output_dir, aip_dir_name)
+        objects_dir = os.path.join(dip_dir, "objects")
+        to_zip_dir = os.path.join(objects_dir, aip_name)
 
     if os.path.exists(dip_dir):
         LOGGER.warning("DIP folder already exists, overwriting")
         shutil.rmtree(dip_dir)
+
     os.makedirs(to_zip_dir)
 
-    LOGGER.info("Moving submissionDocumentation folder")
-    aip_sub_doc = "{}/data/objects/submissionDocumentation".format(aip_dir)
-    if os.path.exists(aip_sub_doc):
-        to_zip_sub_doc = os.path.join(to_zip_dir, "submissionDocumentation")
-        shutil.move(aip_sub_doc, to_zip_sub_doc)
-    else:
-        LOGGER.warning("submissionDocumentation folder not found")
+    if mets_type != "avalon":
+        move_sub_doc(aip_dir, to_zip_dir)
 
     LOGGER.info("Moving METS file")
     aip_mets_file = "{}/data/METS.{}.xml".format(aip_dir, aip_uuid)
@@ -225,23 +228,8 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type):
             continue
 
         premis = techmd.contents.document
-        # Update PREMIS namespace based on version attribute
-        premis_version = premis.get("version", "2.2")
-        try:
-            namespaces["premis"] = premis_map[premis_version]["namespaces"]["premis"]
-        except KeyError:
-            LOGGER.warning(
-                "Could not update namespace for PREMIS version: %s" % premis_version
-            )
-        original_name = premis.findtext("premis:originalName", namespaces=namespaces)
-        if not original_name:
-            LOGGER.warning("premis:originalName could not be found")
-            continue
-
-        string_start = "%transferDirectory%objects/"
-        if original_name[:27] != string_start:
-            LOGGER.warning("premis:originalName not starting with %s", string_start)
-            continue
+        update_premis_ns(premis, namespaces, premis_map)
+        original_name = get_original_name(premis, namespaces)
 
         # Move original file with original name and create parent folders
         dip_file_path = os.path.join(to_zip_dir, original_name[27:])
@@ -251,69 +239,91 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type):
 
         shutil.move(aip_file_path, dip_file_path)
 
-        # Obtain and set the fslastmodified date to the moved files
-        fslastmodified = premis.findtext(
-            "premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:fileinfo/fits:fslastmodified",
-            namespaces=namespaces,
-        )
-        if not fslastmodified:
-            LOGGER.warning("fits/fileinfo/fslastmodified not found")
-            continue
-
-        # Convert from miliseconds to seconds
-        timestamp = int(fslastmodified) // 1000
-        os.utime(dip_file_path, (timestamp, timestamp))
+        if mets_type != "avalon":
+            try:
+                set_fslastmodified(premis, namespaces, dip_file_path)
+            except Exception:
+                LOGGER.warning("fits/fileinfo/fslastmodified not found")
 
     # Modify or copy METS file for DIP based on mets_type argument
     dip_mets_file = os.path.join(dip_dir, "METS.{}.xml".format(aip_uuid))
+
     if mets_type == "atom":
-        LOGGER.info("Creating DIP METS file for AtoM upload.")
-        objects_entry = None
-        for fsentry in fsentries:
-            # Do not delete AIP entry
-            if (
-                fsentry.label == os.path.basename(aip_dir)
-                and fsentry.type.lower() == "directory"
-            ):
-                continue
-
-            # Do not delete objects entry and save it for parenting
-            if fsentry.label == "objects" and fsentry.type.lower() == "directory":
-                objects_entry = fsentry
-                continue
-
-            # Delete all the others
-            mets.remove_entry(fsentry)
-
-        if not objects_entry:
-            LOGGER.error("Could not find objects entry in METS file")
-            return
-
-        # Create new entry for ZIP file
-        entry = metsrw.FSEntry(
-            label="{}.zip".format(aip_name),
-            path="objects/{}.zip".format(aip_name),
-            file_uuid=str(uuid.uuid4()),
-        )
-
-        # Add new entry to objects directory
-        objects_entry.add_child(entry)
-
-        # Create DIP METS file
-        try:
-            mets.write(dip_mets_file, fully_qualified=True, pretty_print=True)
-        except Exception:
-            LOGGER.error("Could not create DIP METS file")
-            return
+        create_dip_mets(aip_dir, aip_name, fsentries, mets, dip_mets_file)
+    elif mets_type == "avalon":
+        # Do not make a METS file
+        pass
     else:
-        LOGGER.info("Copying AIP's METS file.")
-        try:
-            shutil.copy(to_zip_mets_file, dip_mets_file)
-        except Exception:
-            LOGGER.error("Could not create DIP METS file")
-            return
+        copy_aip_mets(to_zip_mets_file, dip_mets_file)
 
-    # Compress to_zip_dir inside the DIP objects folder
+    if mets_type == "avalon":
+        # Update Manifest file with UUIDs
+        update_avalon_manifest(dip_dir, aip_uuid)
+        os.remove(dip_mets_file)
+    else:
+        compress_zip_folder(to_zip_dir)
+        shutil.rmtree(to_zip_dir)
+
+    return dip_dir
+
+
+def create_dip_mets(aip_dir, aip_name, fsentries, mets, dip_mets_file):
+    '''Creates DIP METS file for AtoM upload.'''
+
+    LOGGER.info("Creating DIP METS file for AtoM upload.")
+    objects_entry = None
+    for fsentry in fsentries:
+        # Do not delete AIP entry
+        if (
+            fsentry.label == os.path.basename(aip_dir)
+            and fsentry.type.lower() == "directory"
+        ):
+            continue
+
+        # Do not delete objects entry and save it for parenting
+        if fsentry.label == "objects" and fsentry.type.lower() == "directory":
+            objects_entry = fsentry
+            continue
+
+        # Delete all the others
+        mets.remove_entry(fsentry)
+
+    if not objects_entry:
+        LOGGER.error("Could not find objects entry in METS file")
+        return
+
+    # Create new entry for ZIP file
+    entry = metsrw.FSEntry(
+        label="{}.zip".format(aip_name),
+        path="objects/{}.zip".format(aip_name),
+        file_uuid=str(uuid.uuid4()),
+    )
+
+    # Add new entry to objects directory
+    objects_entry.add_child(entry)
+
+    # Create DIP METS file
+    try:
+        mets.write(dip_mets_file, fully_qualified=True, pretty_print=True)
+    except Exception:
+        LOGGER.error("Could not create DIP METS file")
+        return
+
+
+def copy_aip_mets(to_zip_mets_file, dip_mets_file):
+    '''Copies AIP's METS file.'''
+
+    LOGGER.info("Copying AIP's METS file.")
+    try:
+        shutil.copy(to_zip_mets_file, dip_mets_file)
+    except Exception:
+        LOGGER.error("Could not create DIP METS file")
+        return
+
+
+def compress_zip_folder(to_zip_dir):
+    '''Compresses to_zip_dir inside the DIP objects folder'''
+
     LOGGER.info("Compressing ZIP folder inside objects")
     command = ["7z", "a", "-tzip", "{0}.zip".format(to_zip_dir), to_zip_dir]
     try:
@@ -322,9 +332,87 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type):
         LOGGER.error("Could not compress ZIP folder, error: %s", e.output)
         return
 
-    shutil.rmtree(to_zip_dir)
 
-    return dip_dir
+def move_sub_doc(aip_dir, to_zip_dir):
+    '''Moves submissionDocumentation folder'''
+
+    LOGGER.info("Moving submissionDocumentation folder")
+    aip_sub_doc = "{}/data/objects/submissionDocumentation".format(aip_dir)
+    if os.path.exists(aip_sub_doc):
+        to_zip_sub_doc = os.path.join(to_zip_dir, "submissionDocumentation")
+        shutil.move(aip_sub_doc, to_zip_sub_doc)
+    else:
+        LOGGER.warning("submissionDocumentation folder not found")
+
+
+def set_fslastmodified(premis, namespaces, dip_file_path):
+    '''Obtain and set the fslastmodified date to the moved files'''
+
+    fslastmodified = premis.findtext(
+        "premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:fileinfo/fits:fslastmodified",
+        namespaces=namespaces,
+    )
+    if not fslastmodified:
+        LOGGER.warning("fits/fileinfo/fslastmodified not found")
+
+    # Convert from miliseconds to seconds
+    timestamp = int(fslastmodified) // 1000
+    os.utime(dip_file_path, (timestamp, timestamp))
+
+
+def update_avalon_manifest(dip_dir, aip_uuid):
+    '''Update Avalon Manifest CSV with AIP UUID'''
+
+    files = os.listdir(dip_dir)
+    paths = [fn for fn in files if fn.endswith(".csv")]
+    csv_path = ""
+    if len(paths) == 1:
+        csv_path = dip_dir + "/" + paths[0]
+        tmp_csv_path = dip_dir + "/tmp.csv"
+        with open(csv_path, "r") as csv_input, open((tmp_csv_path), "w") as csv_output:
+            reader = csv.reader(csv_input)
+            writer = csv.writer(csv_output, lineterminator="\n")
+
+            all = []
+            # Skip row one, Add to row two
+            first_row = next(reader)
+            row = next(reader)
+            row.append("Other Identifier")
+            row.append("Other Identifier Label")
+            all.append(first_row)
+            all.append(row)
+
+            for row in reader:
+                row.append(aip_uuid)
+                row.append("other")
+                all.append(row)
+
+            writer.writerows(all)
+        shutil.move(tmp_csv_path, csv_path)
+
+    if not csv_path:
+        LOGGER.error("Manifest file could not be found")
+
+
+def update_premis_ns(premis, namespaces, premis_map):
+    # Update PREMIS namespace based on version attribute
+    premis_version = premis.get("version", "2.2")
+    try:
+        namespaces["premis"] = premis_map[premis_version]["namespaces"]["premis"]
+    except KeyError:
+        LOGGER.warning(
+            "Could not update namespace for PREMIS version: %s" % premis_version
+        )
+
+
+def get_original_name(premis, namespaces):
+    original_name = premis.findtext("premis:originalName", namespaces=namespaces)
+    if not original_name:
+        LOGGER.warning("premis:originalName could not be found")
+    string_start = "%transferDirectory%objects/"
+    if original_name[:27] != string_start:
+        LOGGER.warning("premis:originalName not starting with %s", string_start)
+    return original_name
 
 
 if __name__ == "__main__":
@@ -370,7 +458,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--mets-type",
-        choices=["atom", "storage-service"],
+        choices=["atom", "avalon", "storage-service"],
         default="atom",
         help="Generate METS file for AtoM upload or use the AIP's METS file for Storage Service upload. Default: atom.",
     )

--- a/aips/create_dip.py
+++ b/aips/create_dip.py
@@ -268,7 +268,7 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type):
 
 
 def create_dip_mets(aip_dir, aip_name, fsentries, mets, dip_mets_file):
-    '''Creates DIP METS file for AtoM upload.'''
+    """Creates DIP METS file for AtoM upload."""
 
     LOGGER.info("Creating DIP METS file for AtoM upload.")
     objects_entry = None
@@ -311,7 +311,7 @@ def create_dip_mets(aip_dir, aip_name, fsentries, mets, dip_mets_file):
 
 
 def copy_aip_mets(to_zip_mets_file, dip_mets_file):
-    '''Copies AIP's METS file.'''
+    """Copies AIP's METS file."""
 
     LOGGER.info("Copying AIP's METS file.")
     try:
@@ -322,7 +322,7 @@ def copy_aip_mets(to_zip_mets_file, dip_mets_file):
 
 
 def compress_zip_folder(to_zip_dir):
-    '''Compresses to_zip_dir inside the DIP objects folder'''
+    """Compresses to_zip_dir inside the DIP objects folder"""
 
     LOGGER.info("Compressing ZIP folder inside objects")
     command = ["7z", "a", "-tzip", "{0}.zip".format(to_zip_dir), to_zip_dir]
@@ -334,7 +334,7 @@ def compress_zip_folder(to_zip_dir):
 
 
 def move_sub_doc(aip_dir, to_zip_dir):
-    '''Moves submissionDocumentation folder'''
+    """Moves submissionDocumentation folder"""
 
     LOGGER.info("Moving submissionDocumentation folder")
     aip_sub_doc = "{}/data/objects/submissionDocumentation".format(aip_dir)
@@ -346,7 +346,7 @@ def move_sub_doc(aip_dir, to_zip_dir):
 
 
 def set_fslastmodified(premis, namespaces, dip_file_path):
-    '''Obtain and set the fslastmodified date to the moved files'''
+    """Obtain and set the fslastmodified date to the moved files"""
 
     fslastmodified = premis.findtext(
         "premis:objectCharacteristics/premis:objectCharacteristicsExtension/fits:fits/fits:fileinfo/fits:fslastmodified",
@@ -361,7 +361,7 @@ def set_fslastmodified(premis, namespaces, dip_file_path):
 
 
 def update_avalon_manifest(dip_dir, aip_uuid):
-    '''Update Avalon Manifest CSV with AIP UUID'''
+    """Update Avalon Manifest CSV with AIP UUID"""
 
     files = os.listdir(dip_dir)
     paths = [fn for fn in files if fn.endswith(".csv")]

--- a/aips/create_dip.py
+++ b/aips/create_dip.py
@@ -69,7 +69,7 @@ def main(
     tmp_dir,
     output_dir,
     mets_type="atom",
-    dip_type="storage-service",
+    dip_type="zipped-objects",
 ):
     LOGGER.info("Starting DIP creation from AIP: %s", aip_uuid)
 
@@ -183,7 +183,7 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type, dip_type):
     aip_name = aip_dir_name[:-37]
 
     if dip_type == "avalon":
-        dip_dir = os.path.join(output_dir, "{}/{}".format(aip_name, aip_uuid))
+        dip_dir = os.path.join(output_dir, aip_name, aip_uuid)
         to_zip_dir = dip_dir
     else:
         dip_dir = os.path.join(output_dir, aip_dir_name)
@@ -374,8 +374,8 @@ def update_avalon_manifest(dip_dir, aip_uuid):
     paths = [fn for fn in files if fn.endswith(".csv")]
     csv_path = ""
     if len(paths) == 1:
-        csv_path = dip_dir + "/" + paths[0]
-        tmp_csv_path = dip_dir + "/tmp.csv"
+        csv_path = os.path.join(dip_dir, paths[0])
+        tmp_csv_path = os.path.join(dip_dir, "/tmp.csv")
         with open(csv_path, "r") as csv_input, open((tmp_csv_path), "w") as csv_output:
             reader = csv.reader(csv_input)
             writer = csv.writer(csv_output, lineterminator="\n")

--- a/tests/test_create_dip.py
+++ b/tests/test_create_dip.py
@@ -74,7 +74,9 @@ class TestCreateDip(unittest.TestCase):
             # Extract it
             aip_dir = create_dip.extract_aip(aip_path, AIP_UUID, TMP_DIR)
             # Test DIP creation
-            dip_dir = create_dip.create_dip(aip_dir, AIP_UUID, OUTPUT_DIR, "atom", "zipped-objects")
+            dip_dir = create_dip.create_dip(
+                aip_dir, AIP_UUID, OUTPUT_DIR, "atom", "zipped-objects"
+            )
             assert dip_dir == "{}/{}-{}".format(OUTPUT_DIR, TRANSFER_NAME, AIP_UUID)
             assert os.path.isdir(dip_dir)
             # Check a METS file exists
@@ -128,5 +130,7 @@ class TestCreateDip(unittest.TestCase):
 
     def test_create_dip_fail_no_aip_dir(self):
         """Test that a DIP creation fails with a bad path."""
-        dip_dir = create_dip.create_dip("bad_path", AIP_UUID, OUTPUT_DIR, "atom", "zipped-objects")
+        dip_dir = create_dip.create_dip(
+            "bad_path", AIP_UUID, OUTPUT_DIR, "atom", "zipped-objects"
+        )
         assert dip_dir is None

--- a/tests/test_create_dip.py
+++ b/tests/test_create_dip.py
@@ -74,7 +74,7 @@ class TestCreateDip(unittest.TestCase):
             # Extract it
             aip_dir = create_dip.extract_aip(aip_path, AIP_UUID, TMP_DIR)
             # Test DIP creation
-            dip_dir = create_dip.create_dip(aip_dir, AIP_UUID, OUTPUT_DIR, "atom")
+            dip_dir = create_dip.create_dip(aip_dir, AIP_UUID, OUTPUT_DIR, "atom", "zipped-objects")
             assert dip_dir == "{}/{}-{}".format(OUTPUT_DIR, TRANSFER_NAME, AIP_UUID)
             assert os.path.isdir(dip_dir)
             # Check a METS file exists
@@ -128,5 +128,5 @@ class TestCreateDip(unittest.TestCase):
 
     def test_create_dip_fail_no_aip_dir(self):
         """Test that a DIP creation fails with a bad path."""
-        dip_dir = create_dip.create_dip("bad_path", AIP_UUID, OUTPUT_DIR, "atom")
+        dip_dir = create_dip.create_dip("bad_path", AIP_UUID, OUTPUT_DIR, "atom", "zipped-objects")
         assert dip_dir is None


### PR DESCRIPTION
This is connected to https://github.com/archivematica/Issues/issues/643. 

Former PR: https://github.com/artefactual/automation-tools/pull/107

This incorporates an "avalon" METS type, to fulfill the obligations of the connected issue above. In order to do this in a logical way, I also moved some of the logic out of the create_dip function and into smaller, easier-to-digest functions.

I tested the Avalon workflow as well as the Atom workflow, but testing should ensure that the new storage-service method is working fine as well.

@jraddaoui reviewed my previous PR. Radda, you had a bunch of questions that I may or may not have answered in direct message about the structure of the AIP. I'll recap briefly... Files are expected to come into Archivematica structured in a specific way, and the DIP creation should also be formatted in a specific way.

Incoming: Only one CSV at the top level of the set of files (the "manifest file"; can be named anything but must be structured in a specific way.)
Outgoing: Transfer name represents the folder files must end up in. Subfolder as UUID was not required by the spec but I added it to ensure uniqueness when moving lots of files.