### PR TITLE
Update installation instructions

### DIFF
--- a/etc/transfer-script.sh
+++ b/etc/transfer-script.sh
@@ -2,4 +2,10 @@
 # transfer script example
 # /etc/archivematica/automation-tools/transfer-script.sh
 cd /usr/lib/archivematica/automation-tools/
-/usr/share/python/automation-tools/bin/python -m transfers.transfer --user <user> --api-key <apikey>  --ss-user <user> --ss-api-key <apikey> --transfer-source <transfer_source_uuid> --config-file <config_file>
+/usr/share/python/venv/automation-tools/bin/python -m transfers.transfer 
+  --user <user> 
+  --api-key <apikey>  
+  --ss-user <user> 
+  --ss-api-key <apikey> 
+  --transfer-source <transfer_source_uuid> 
+  --config-file <config_file>


### PR DESCRIPTION
When using the installation instructions for the automation tools I ran into some small access related issues. Besides this I also added some small clarifications for docker users. 

For the instructions I assumed that most of the access rights should stay with the administrator. A reasonable alternative would be to make the archivematica user the owner of all automation-tools. I don't know what you guys think is best?

Fixes: archivematica/issues#729