### PR TITLE
Fix premis:originalName parsing, refs #128

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,15 @@
 # Sublime files
 *.sublime-*
 
+# VS Code files
+.vscode
+
 # Log files
 *.log.[0-9]
 *.log
+
+# Python3 venv
+.venv
 
 # Tox files
 .tox/

--- a/aips/create_dip.py
+++ b/aips/create_dip.py
@@ -239,10 +239,14 @@ def create_dip(aip_dir, aip_uuid, output_dir, mets_type, dip_type):
 
         premis = techmd.contents.document
         update_premis_ns(premis, namespaces, premis_map)
-        original_name = get_original_name(premis, namespaces)
 
-        # Move original file with original name and create parent folders
-        dip_file_path = os.path.join(to_zip_dir, original_name[27:])
+        original_filename = get_original_filename(premis, namespaces)
+        if not original_filename:
+            LOGGER.warning("Could not get original file name from premis:originalName")
+            continue
+
+        # Move original file with original file name and create parent folders
+        dip_file_path = os.path.join(to_zip_dir, original_filename)
         dip_dir_path = os.path.dirname(dip_file_path)
         if not os.path.exists(dip_dir_path):
             os.makedirs(dip_dir_path)
@@ -411,15 +415,15 @@ def update_premis_ns(premis, namespaces, premis_map):
         )
 
 
-def get_original_name(premis, namespaces):
+def get_original_filename(premis, namespaces):
     """Get original filename from PREMIS record"""
     original_name = premis.findtext("premis:originalName", namespaces=namespaces)
     if not original_name:
         LOGGER.warning("premis:originalName could not be found")
-    string_start = "%transferDirectory%objects/"
-    if original_name[:27] != string_start:
-        LOGGER.warning("premis:originalName not starting with %s", string_start)
-    return original_name
+        return None
+
+    # Strip path and return file name with extension
+    return os.path.basename(original_name)
 
 
 if __name__ == "__main__":

--- a/aips/create_dip.py
+++ b/aips/create_dip.py
@@ -417,13 +417,23 @@ def update_premis_ns(premis, namespaces, premis_map):
 
 def get_original_filename(premis, namespaces):
     """Get original filename from PREMIS record"""
+
     original_name = premis.findtext("premis:originalName", namespaces=namespaces)
     if not original_name:
         LOGGER.warning("premis:originalName could not be found")
         return None
 
-    # Strip path and return file name with extension
-    return os.path.basename(original_name)
+    # Strip the path prefix from the file path, and return the remainder
+    path_prefixes = ["%transferDirectory%objects/", "%transferDirectory%data/"]
+    for pp in path_prefixes:
+        if original_name[: len(pp)] == pp:
+            return original_name[len(pp) :]
+
+    LOGGER.warning(
+        'premis:originalName "%s" has an invalid prefix, it must be one of (%s)',
+        original_name,
+        ", ".join(path_prefixes),
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_create_dip.py
+++ b/tests/test_create_dip.py
@@ -149,5 +149,4 @@ class TestCreateDip(unittest.TestCase):
     def test_get_original_relpath_warn_invalid_prefix(self):
         path = "%transferDirectory%datas/folder1/file5.txt"
 
-        with self.assertLogs(level="WARN"):
-            create_dip.get_original_relpath(path)
+        assert create_dip.get_original_relpath(path) is None

--- a/tests/test_create_dip.py
+++ b/tests/test_create_dip.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-import zipfile
+
 import os
 import time
 import unittest
 import vcr
+import zipfile
 
 import amclient
 
@@ -134,3 +135,19 @@ class TestCreateDip(unittest.TestCase):
             "bad_path", AIP_UUID, OUTPUT_DIR, "atom", "zipped-objects"
         )
         assert dip_dir is None
+
+    def test_get_original_relpath_objects_dir(self):
+        path = "%transferDirectory%objects/folder1/file5.txt"
+
+        assert create_dip.get_original_relpath(path) == "folder1/file5.txt"
+
+    def test_get_original_relpath_data_dir(self):
+        path = "%transferDirectory%data/folder1/file5.txt"
+
+        assert create_dip.get_original_relpath(path) == "folder1/file5.txt"
+
+    def test_get_original_relpath_warn_invalid_prefix(self):
+        path = "%transferDirectory%datas/folder1/file5.txt"
+
+        with self.assertLogs(level="WARN"):
+            create_dip.get_original_relpath(path)


### PR DESCRIPTION
Use `os.path.basename()` to get file names from the
`<premis:originalName>` path.

The previously assumed path of `%transferDirectory%objects` is not valid
for BagIt transfers, which lead to truncating the first three characters
of the filename in the DIP objects zip file.