### PR TITLE
Fix transfer_async.py and add ability to specify processing config by name

### DIFF
--- a/etc/transfers.conf
+++ b/etc/transfers.conf
@@ -1,8 +1,13 @@
 # automation-tools:transfers configuration file example
 # /etc/archivematica/automation-tools/transfers.conf
 
+# The processingconfig option is used by transfer_async.py to include
+# the name of the processing config in the "/api/v2beta/package/" API
+# call which starts the transfer, and is ignored in transfer.py.
+
 [transfers]
 logfile = /var/log/archivematica/automation-tools/transfers.log
 databasefile = /var/archivematica/automation-tools/transfers.db
 pidfile = /var/archivematica/automation-tools/transfers-pid.lck
+processingconfig = automated
 scriptextensions = .py:.sh

--- a/fixtures/vcr_cassettes/test_transfer_async_api_create_package.yaml
+++ b/fixtures/vcr_cassettes/test_transfer_async_api_create_package.yaml
@@ -1,0 +1,186 @@
+interactions:
+- request:
+    body: '{"name": "standard_1", "type": "standard", "accession": "standard_1", "path":
+      "ODEwN2U4ZDEtYzM5MC00ZmUyLThkNTEtMzBmODllZTJlNGQ0OnN0YW5kYXJkXzE=", "processing_config":
+      "default"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://127.0.0.1:62080/api/v2beta/package/
+  response:
+    body:
+      string: '{"id": "06c28572-4506-48ba-904e-07938dabdb7d"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jun 2022 20:02:14 GMT
+      Server:
+      - nginx/1.20.2
+      Vary:
+      - Accept-Language, Cookie
+      X-Archivematica-ID:
+      - 6ba850ec-ec7f-4a53-9a8a-f3598aa39b93
+      X-Archivematica-Version:
+      - 1.14.0
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: '{"name": "standard_1_1", "type": "standard", "accession": "standard_1_1",
+      "path": "ODEwN2U4ZDEtYzM5MC00ZmUyLThkNTEtMzBmODllZTJlNGQ0OnN0YW5kYXJkXzE=",
+      "processing_config": "default"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://127.0.0.1:62080/api/v2beta/package/
+  response:
+    body:
+      string: '{"id": "f8be5d0f-0692-4025-829c-9a029b96087e"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jun 2022 20:02:14 GMT
+      Server:
+      - nginx/1.20.2
+      Vary:
+      - Accept-Language, Cookie
+      X-Archivematica-ID:
+      - 6ba850ec-ec7f-4a53-9a8a-f3598aa39b93
+      X-Archivematica-Version:
+      - 1.14.0
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: '{"name": "dspace_1.zip", "type": "dspace", "accession": "dspace_1.zip",
+      "path": "ODEwN2U4ZDEtYzM5MC00ZmUyLThkNTEtMzBmODllZTJlNGQ0OmRzcGFjZV8xLnppcA==",
+      "processing_config": "default"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '183'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://127.0.0.1:62080/api/v2beta/package/
+  response:
+    body:
+      string: '{"id": "fb6adb0f-8e6b-4f08-822f-00ec0311576b"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jun 2022 20:02:14 GMT
+      Server:
+      - nginx/1.20.2
+      Vary:
+      - Accept-Language, Cookie
+      X-Archivematica-ID:
+      - 6ba850ec-ec7f-4a53-9a8a-f3598aa39b93
+      X-Archivematica-Version:
+      - 1.14.0
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: '{"name": "dspace_1_1.zip", "type": "dspace", "accession": "dspace_1_1.zip",
+      "path": "ODEwN2U4ZDEtYzM5MC00ZmUyLThkNTEtMzBmODllZTJlNGQ0OmRzcGFjZV8xLnppcA==",
+      "processing_config": "default"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '187'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://127.0.0.1:62080/api/v2beta/package/
+  response:
+    body:
+      string: '{"id": "15c585ca-c28d-4d2d-9ad2-72fe7d49fdd0"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jun 2022 20:02:14 GMT
+      Server:
+      - nginx/1.20.2
+      Vary:
+      - Accept-Language, Cookie
+      X-Archivematica-ID:
+      - 6ba850ec-ec7f-4a53-9a8a-f3598aa39b93
+      X-Archivematica-Version:
+      - 1.14.0
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/tests/test_transfers_async.py
+++ b/tests/test_transfers_async.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import collections
+import unittest
+
+import vcr
+
+from transfers import transfer_async, models
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+AM_URL = "http://127.0.0.1:62080"
+SS_URL = "http://127.0.0.1:62081"
+USER = "test"
+API_KEY = "test"
+SS_USER = "test"
+SS_KEY = "test"
+
+TS_LOCATION_UUID = "8107e8d1-c390-4fe2-8d51-30f89ee2e4d4"
+PATH_PREFIX = b"SampleTransfers"
+DEPTH = 1
+COMPLETED = set()
+FILES = False
+
+
+class TestAutomateTransfers(unittest.TestCase):
+    def setUp(self):
+        models.init_session(databasefile=":memory:")
+
+        # Setup some test data.
+        transfers_dir = (
+            "/var/archivematica/sharedDirectory/watchedDirectories/" "activeTransfers"
+        )
+        Result = collections.namedtuple(
+            "Result", "transfer_type target transfer_name transfer_abs_path"
+        )
+        self.start_tests = [
+            Result(
+                transfer_type="standard",
+                target="standard_1",
+                transfer_name="standard_1",
+                transfer_abs_path="{}/standardTransfer/standard_1/".format(
+                    transfers_dir
+                ),
+            ),
+            Result(
+                transfer_type="standard",
+                target="standard_1",
+                transfer_name="standard_1_1",
+                transfer_abs_path="{}/standardTransfer/standard_1_1/".format(
+                    transfers_dir
+                ),
+            ),
+            Result(
+                transfer_type="dspace",
+                target="dspace_1.zip",
+                transfer_name="dspace_1.zip",
+                transfer_abs_path="{}/Dspace/dspace_1.zip".format(transfers_dir),
+            ),
+            Result(
+                transfer_type="dspace",
+                target="dspace_1.zip",
+                transfer_name="dspace_1_1.zip",
+                transfer_abs_path="{}/Dspace/dspace_1_1.zip".format(transfers_dir),
+            ),
+        ]
+
+    @vcr.use_cassette(
+        "fixtures/vcr_cassettes/" "test_transfer_async_api_create_package.yaml"
+    )
+    def test_call_start_transfer(self):
+        """Provide an integration test as best as we can for transfer_async's
+        _start_transfer method, which overrides that from the transfer module.
+        """
+        for test in self.start_tests:
+            models.init_session(databasefile=":memory:")
+            with mock.patch(
+                "transfers.transfer_async.get_next_transfer"
+            ) as mock_get_next_transfer:
+                mock_get_next_transfer.return_value = test.target.encode()
+                res = transfer_async._api_create_package(
+                    am_url=AM_URL,
+                    am_user=USER,
+                    am_api_key=API_KEY,
+                    name=test.transfer_name,
+                    package_type=test.transfer_type,
+                    accession=test.transfer_name,
+                    ts_location_uuid=TS_LOCATION_UUID,
+                    ts_path=test.target.encode(),
+                    config_file="config.cfg",
+                )
+                with mock.patch(
+                    "transfers.transfer_async._api_create_package"
+                ) as mock_api_create_package:
+                    mock_api_create_package.return_value = res
+                    new_transfer = transfer_async._start_transfer(
+                        ss_url=SS_URL,
+                        ss_user=SS_USER,
+                        ss_api_key=SS_KEY,
+                        ts_location_uuid=TS_LOCATION_UUID,
+                        ts_path="",
+                        depth="test",
+                        am_url=AM_URL,
+                        am_user=USER,
+                        am_api_key=API_KEY,
+                        transfer_type="standard",
+                        see_files=False,
+                        config_file="config.cfg",
+                    )
+                    assert new_transfer.path.decode() == test.target
+                    assert new_transfer.current is True
+                    assert new_transfer.unit_type == "transfer"
+                    # Make a secondary call to the database to see if we can
+                    # retrieve our information. Obviously this should not have
+                    # changed since we wrote it to memory.
+                    unit = models.retrieve_unit_by_type_and_uuid(
+                        new_transfer.uuid, "transfer"
+                    )
+                    assert unit.uuid == new_transfer.uuid
+                    assert unit.current is True
+                    assert unit.unit_type == "transfer"


### PR DESCRIPTION
This pull request adds a `processingconfig` setting in the `transfers.conf` file that allows users to specify which processing configuration to use for transfers created with the `transfer_async.py` script.

`transfer_async.py` wasn't working following a refactor of `transfer.py`, so I've also fixed a few things (a character encoding issue, out-of-date function signature, and switched to using the existing helpers in the `models` module for database interactions) to enable this feature to work.

I also added an integration test for `transfer_async.py` to help prevent future breaking changes.