### PR TITLE
Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 18.9b0
+  rev: 22.8.0
   hooks:
   - id: black
     args: [--safe, --quiet]
     language_version: python3
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.7
+- repo: https://github.com/pycqa/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
     language_version: python3

--- a/transfers/models.py
+++ b/transfers/models.py
@@ -11,8 +11,7 @@ transfer_session = None
 
 
 class Unit(Base):
-    """Object that represents transfer units in the automation tools database.
-    """
+    """Object that represents transfer units in the automation tools database."""
 
     __tablename__ = "unit"
 


### PR DESCRIPTION
This updates the versions of the pre-commit dependencies to support Python 3.6 and fixes the URL of the flake8 repository.

Connected to https://github.com/archivematica/Issues/issues/1558