### PR TITLE
Add required options to transfer script template.

### DIFF
--- a/etc/transfer-script.sh
+++ b/etc/transfer-script.sh
@@ -2,10 +2,12 @@
 # transfer script example
 # /etc/archivematica/automation-tools/transfer-script.sh
 cd /usr/lib/archivematica/automation-tools/
-/usr/share/python/automation-tools/venv/bin/python -m transfers.transfer
-  --user <user> 
-  --api-key <apikey>  
-  --ss-user <user> 
-  --ss-api-key <apikey> 
-  --transfer-source <transfer_source_uuid> 
+/usr/share/python/automation-tools/venv/bin/python -m transfers.transfer \
+  --am-url <archivematica_url> \
+  --ss-url <storage_service_url> \
+  --user <archivematica_user> \
+  --api-key <archivematica_api_key> \ 
+  --ss-user <storage_service_user> \
+  --ss-api-key <storage_service_api_key> \
+  --transfer-source <transfer_source_uuid> \
   --config-file <config_file>


### PR DESCRIPTION
Added missing required command-line options (Archivematica and storage
service URLs) to transfer script tempate and added backslashes so
command-line options aren't treated as separate commands.