### PR TITLE
Upgrade dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.2
+  rev: v3.16.0
   hooks:
   - id: pyupgrade
     args: [--py38-plus]
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v3.12.0
+  rev: v3.13.0
   hooks:
   - id: reorder-python-imports
     args: [--py38-plus]
@@ -15,14 +15,14 @@ repos:
   - id: black
     args: [--safe, --quiet]
 - repo: https://github.com/pycqa/flake8
-  rev: "7.0.0"
+  rev: "7.1.0"
   hooks:
   - id: flake8
     additional_dependencies:
-    - flake8-bugbear==24.2.6
+    - flake8-bugbear==24.4.26
     - flake8-comprehensions==3.14.0
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.39.0
+  rev: v0.41.0
   hooks:
   - id: markdownlint
     exclude: |

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ corner, then select 'Your profile'. The API key will be displayed at the bottom
 of the page.
 
 To get the Storage Service API key, log in to the Storage Service as the user
-you wish to authenticate as. From the dashboard, go to *Administration > Users*
+you wish to authenticate as. From the dashboard, go to _Administration > Users_
 and select 'Edit' for the user you want the key for. The API key will be
 displayed at the bottom of the page. Storage Service versions earlier than
 `0.8.x` do not require an API key, and will not provide one. In that case, fill
@@ -825,7 +825,7 @@ above about finding the Archivematica and Storage Service API keys. An example
 configuration with placeholder parameters is provided in
 [reingestconfig.json](transfers/reingestconfig.json)
 
-*Reingest.py* is best used via the shell script provided in the
+_Reingest.py_ is best used via the shell script provided in the
 [_transfers/examples/reingest_](transfers/examples/reingest) folder. As it is
 designed for bulk-reingest, it is best used in conjunction with a cronfile, an
 example of which is provided in the same folder.
@@ -883,7 +883,7 @@ INFO      2018-10-26 00:00:03 reingest.py:194  Removing PID for current process.
 ```
 
 1. Following completion of the first reingest, a second is started and we can
-   see similar log entries to those in *1.*
+   see similar log entries to those in _1._
 
 ```shell
 $ ./run-reingest.sh
@@ -935,13 +935,13 @@ information could be found by looking up the status of the microservices:
 
 Via the user interface:
 
-- *http://{archivematica-url}}/transfer/{UUID}/*
-- *http://{archivematica-url}}/ingest/{UUID}/*
+- _http://{archivematica-url}}/transfer/{UUID}/_
+- _http://{archivematica-url}}/ingest/{UUID}/_
 
 Via the API (users will need to filter on package UUID):
 
-- *http://{archivematica-url}}/transfer/status/*
-- *http://{archivematica-url}}/ingest/status/*
+- _http://{archivematica-url}}/transfer/status/_
+- _http://{archivematica-url}}/ingest/status/_
 
 ## Related Projects
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 amclient==1.3.0
     # via -r requirements.txt
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -r requirements.txt
     #   requests
@@ -14,7 +14,7 @@ charset-normalizer==3.3.2
     # via
     #   -r requirements.txt
     #   requests
-coverage[toml]==7.5.1
+coverage[toml]==7.5.3
     # via pytest-cov
 exceptiongroup==1.2.1
     # via pytest
@@ -34,17 +34,17 @@ lxml==5.2.2
     #   metsrw
 metsrw==0.5.1
     # via -r requirements.txt
-packaging==24.0
+packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-pytest==8.2.1
+pytest==8.2.2
     # via
     #   -r requirements-dev.in
     #   pytest-cov
 pytest-cov==5.0.0
     # via -r requirements-dev.in
-requests==2.32.1
+requests==2.32.3
     # via
     #   -r requirements.txt
     #   amclient
@@ -54,7 +54,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements.txt
     #   amclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 amclient==1.3.0
     # via -r requirements.in
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -18,13 +18,13 @@ lxml==5.2.2
     # via metsrw
 metsrw==0.5.1
     # via -r requirements.in
-requests==2.32.1
+requests==2.32.3
     # via
     #   -r requirements.in
     #   amclient
 sqlalchemy==1.4.52
     # via -r requirements.in
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements.in
     #   amclient


### PR DESCRIPTION
`README.md` has been updated because its [emphasis styles](https://github.com/DavidAnson/markdownlint/blob/main/doc/md049.md) were mixing `_` and `*` characters. Detection for that has been improved in the [v0.40.0 release](https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.40.0) of `markdownlint-cli`.